### PR TITLE
Add app icon SVG with landscape design

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbbf24"/>
+      <stop offset="55%" stop-color="#a16207"/>
+      <stop offset="100%" stop-color="#30a0ff"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fef7ed"/>
+      <stop offset="100%" stop-color="#fde68a"/>
+    </linearGradient>
+    <clipPath id="frame">
+      <rect x="10" y="12" width="44" height="40" rx="6" ry="6"/>
+    </clipPath>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" ry="14" fill="url(#bg)"/>
+  <g clip-path="url(#frame)">
+    <rect x="10" y="12" width="44" height="40" fill="url(#sky)"/>
+    <circle cx="22" cy="24" r="5" fill="#f59e0b"/>
+    <path d="M10 48 L22 32 L31 40 L41 28 L54 48 L54 52 L10 52 Z" fill="#78350f"/>
+    <path d="M22 32 L28 40 L31 40 Z M41 28 L47 38 L54 48 L54 44 L41 28 Z" fill="#451a03" opacity="0.35"/>
+  </g>
+  <rect x="10" y="12" width="44" height="40" rx="6" ry="6" fill="none" stroke="#451a03" stroke-opacity="0.3" stroke-width="1.5"/>
+</svg>


### PR DESCRIPTION
## Summary
Added a new SVG icon file for the application featuring a scenic landscape design with gradient backgrounds and layered visual elements.

## Changes
- Created `src/app/icon.svg` with a 64x64px SVG icon
- Implemented a multi-layered landscape scene with:
  - Gradient background transitioning from golden to blue tones
  - Sky gradient with warm cream-to-yellow colors
  - Sun element (orange circle)
  - Mountain/terrain silhouettes with depth shading
  - Rounded frame with subtle border styling

## Implementation Details
- Used SVG gradients (`linearGradient`) for smooth color transitions
- Applied `clipPath` to constrain landscape elements within a rounded rectangle frame
- Layered shapes with opacity variations to create depth and shadow effects
- Rounded corners (14px) on outer container and 6px on inner frame for modern appearance

https://claude.ai/code/session_01Aash1Fgi741xGKJzQJ3TsM