### PR TITLE
feat: implement GitHub OAuth login via lfkdsk-auth broker

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import LoginOptions from '@/components/LoginOptions';
 
 export const metadata = {
@@ -7,7 +8,9 @@ export const metadata = {
 export default function LoginPage() {
   return (
     <div style={{ display: 'grid', placeItems: 'center', minHeight: 'calc(100dvh - 64px)' }}>
-      <LoginOptions />
+      <Suspense fallback={null}>
+        <LoginOptions />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,48 +2,71 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { validateCurrentToken, clearGitHubToken } from '@/lib/github';
+import { consumeOAuthFragment, storeAuthData } from '@/lib/auth';
 
 export default function HomePage() {
   const router = useRouter();
 
   useEffect(() => {
-    const checkAuthAndRedirect = async () => {
+    const init = async () => {
+      // Step 1: check whether this is an OAuth callback (/#oauth_token=…).
+      // This must happen before any token validation so the new token is
+      // written to localStorage before we check it.
+      const oauthResult = consumeOAuthFragment();
+
+      if (oauthResult) {
+        if ('error' in oauthResult) {
+          // OAuth failed — surface the error on the login page.
+          router.push(`/login?error=${encodeURIComponent(oauthResult.error)}`);
+          return;
+        }
+
+        // Token received — fetch the user profile and persist everything.
+        try {
+          const resp = await fetch('https://api.github.com/user', {
+            headers: { Authorization: `token ${oauthResult.token}` },
+          });
+          if (!resp.ok) throw new Error('Failed to fetch GitHub user');
+          const user = await resp.json();
+          storeAuthData(oauthResult.token, user);
+          router.push('/main');
+        } catch {
+          router.push('/login?error=Failed+to+fetch+GitHub+user+profile');
+        }
+        return;
+      }
+
+      // Step 2: normal page load — validate any existing token.
       try {
         const isValid = await validateCurrentToken();
-        
         if (isValid) {
-          // Token有效，跳转到main页面
           router.push('/main');
         } else {
-          // Token无效，清理缓存并跳转到登录页面
           clearGitHubToken();
           router.push('/login');
         }
-      } catch (error) {
-        // 验证失败，清理缓存并跳转到登录页面
-        console.error('Token validation failed:', error);
+      } catch {
         clearGitHubToken();
         router.push('/login');
       }
     };
 
-    checkAuthAndRedirect();
+    init();
   }, [router]);
 
-  // 显示加载状态
   return (
-    <div style={{ 
-      display: 'flex', 
-      justifyContent: 'center', 
-      alignItems: 'center', 
+    <div style={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
       height: '100vh',
       flexDirection: 'column',
       gap: '16px'
     }}>
       <div>检查登录状态...</div>
-      <div style={{ 
-        width: '32px', 
-        height: '32px', 
+      <div style={{
+        width: '32px',
+        height: '32px',
         border: '3px solid #f3f3f3',
         borderTop: '3px solid #3498db',
         borderRadius: '50%',

--- a/src/components/LoginOptions.tsx
+++ b/src/components/LoginOptions.tsx
@@ -1,22 +1,26 @@
 'use client';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import { validateCurrentToken } from '@/lib/github';
+import { initiateGitHubOAuth } from '@/lib/auth';
 
 export default function LoginOptions() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const [oauthError, setOauthError] = useState<string | null>(null);
 
-  // 检查是否已有有效token，如果有则跳转到main
+  useEffect(() => {
+    const error = searchParams.get('error');
+    if (error) setOauthError(decodeURIComponent(error));
+  }, [searchParams]);
+
   useEffect(() => {
     const checkExistingAuth = async () => {
       try {
         const isValid = await validateCurrentToken();
-        if (isValid) {
-          router.push('/main');
-        }
-      } catch (error) {
-        // Token验证失败，留在登录页面
-        console.log('No valid token found, staying on login page');
+        if (isValid) router.push('/main');
+      } catch {
+        // no valid token — stay on login page
       }
     };
 
@@ -24,8 +28,7 @@ export default function LoginOptions() {
   }, [router]);
 
   const onGithubLogin = () => {
-    // TODO: integrate GitHub OAuth
-    console.log('GitHub OAuth login clicked');
+    initiateGitHubOAuth();
   };
 
   return (
@@ -41,10 +44,15 @@ export default function LoginOptions() {
         </button>
       </div>
 
+      {oauthError ? (
+        <p role="alert" className="error">{oauthError}</p>
+      ) : null}
+
       <style jsx>{`
         .wrap { display: grid; gap: 16px; padding: 12px 0; }
         .brand { font-size: 40px; line-height: 1; margin: 8px 0; }
         .actions { display: grid; gap: 12px; width: 260px; }
+        .error { color: #dc2626; font-size: 14px; max-width: 280px; text-align: center; }
         .btn {
           height: 44px;
           min-width: 220px;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,9 @@
-// GitHub OAuth认证配置和工具函数
+// GitHub OAuth config — client_id is intentionally public (travels in every
+// authorize URL). The secret lives only in the lfkdsk-auth Cloudflare Worker.
+const GITHUB_CLIENT_ID = process.env.NEXT_PUBLIC_GITHUB_CLIENT_ID || 'Ov23liCg29llKxJ7b0jv';
+const AUTH_CALLBACK_URL = 'https://auth.lfkdsk.org/picg/callback';
+const OAUTH_SCOPE = 'repo';
+const STATE_KEY = 'oauth_state';
 
 export interface GitHubUser {
   id: number;
@@ -13,65 +18,103 @@ export interface GitHubUser {
   created_at: string;
 }
 
+// Redirect the browser to GitHub's OAuth authorize page. A random state is
+// stored in sessionStorage so consumeOAuthFragment() can validate it on return.
+export function initiateGitHubOAuth(): void {
+  const state = crypto.randomUUID();
+  sessionStorage.setItem(STATE_KEY, state);
+
+  const params = new URLSearchParams({
+    client_id: GITHUB_CLIENT_ID,
+    redirect_uri: AUTH_CALLBACK_URL,
+    scope: OAUTH_SCOPE,
+    state,
+  });
+
+  window.location.href = `https://github.com/login/oauth/authorize?${params.toString()}`;
+}
+
+export interface OAuthSuccess {
+  token: string;
+  scope: string;
+}
+export interface OAuthError {
+  error: string;
+}
+
+// Call this once on the page that receives the OAuth redirect (root "/").
+// The lfkdsk-auth worker appends results as a URL fragment:
+//   /#oauth_token=<tok>&oauth_scope=<scope>&state=<s>
+//   /#oauth_error=<msg>&state=<s>
+//
+// Returns null if the fragment contains no OAuth payload (normal page load).
+export function consumeOAuthFragment(): OAuthSuccess | OAuthError | null {
+  if (typeof window === 'undefined') return null;
+
+  const hash = window.location.hash.slice(1);
+  if (!hash) return null;
+
+  const params = new URLSearchParams(hash);
+  if (!params.has('oauth_token') && !params.has('oauth_error')) return null;
+
+  // Consume the fragment immediately — prevents re-processing on refresh.
+  history.replaceState(null, '', window.location.pathname + window.location.search);
+
+  const oauthError = params.get('oauth_error');
+  if (oauthError) return { error: oauthError };
+
+  const token = params.get('oauth_token');
+  const scope = params.get('oauth_scope') || '';
+  const returnedState = params.get('state') || '';
+
+  // Validate CSRF state if we stored one.
+  const expectedState = sessionStorage.getItem(STATE_KEY);
+  sessionStorage.removeItem(STATE_KEY);
+  if (expectedState && returnedState !== expectedState) {
+    return { error: 'State mismatch — possible CSRF, please try again' };
+  }
+
+  if (!token) return { error: 'No access token received from GitHub' };
+
+  return { token, scope };
+}
+
 // 获取存储的用户信息
 export function getStoredUser(): GitHubUser | null {
   if (typeof window === 'undefined') return null;
-  
+
   try {
     const userStr = localStorage.getItem('gh_user');
     if (!userStr) return null;
-    
     return JSON.parse(userStr);
-  } catch (error) {
-    console.error('Failed to parse stored user data:', error);
+  } catch {
     return null;
   }
 }
 
-// 存储认证信息
+// 存储 OAuth 认证信息（token + 用户信息 + 过期时间）
 export function storeAuthData(token: string, user: GitHubUser): void {
   if (typeof window === 'undefined') return;
-  
-  try {
-    // 存储token
-    localStorage.setItem('gh_token', token);
-    
-    // 存储用户信息
-    localStorage.setItem('gh_user', JSON.stringify(user));
-    
-    // 设置过期时间（30天）
-    const expiryDate = new Date();
-    expiryDate.setDate(expiryDate.getDate() + 30);
-    localStorage.setItem('gh_token_expiry', expiryDate.toISOString());
-    
-    console.log('Auth data stored successfully');
-  } catch (error) {
-    console.error('Failed to store auth data:', error);
-  }
+
+  localStorage.setItem('gh_token', token);
+  localStorage.setItem('gh_user', JSON.stringify(user));
+
+  const expiry = new Date();
+  expiry.setDate(expiry.getDate() + 30);
+  localStorage.setItem('gh_token_expiry', expiry.toISOString());
 }
 
 // 清除所有认证数据
 export function clearAuthData(): void {
   if (typeof window === 'undefined') return;
-  
-  const keysToRemove = [
-    'gh_token',
-    'gh_user',
-    'gh_token_expiry',
-    'github_token', // 兼容旧版本
-    'oauth_state'
-  ];
-  
-  keysToRemove.forEach(key => {
-    localStorage.removeItem(key);
-    sessionStorage.removeItem(key);
+
+  const keys = ['gh_token', 'gh_user', 'gh_token_expiry', 'github_token', STATE_KEY];
+  keys.forEach(k => {
+    localStorage.removeItem(k);
+    sessionStorage.removeItem(k);
   });
-  
-  // 清除cookies
-  const cookiesToClear = ['gh_token', 'github_token'];
-  cookiesToClear.forEach(cookieName => {
-    document.cookie = `${cookieName}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
+
+  ['gh_token', 'github_token'].forEach(name => {
+    document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
   });
-  
-  console.log('Auth data cleared');
 }


### PR DESCRIPTION
## Summary

- Replaces the no-op "使用 GitHub 登录" button with a real OAuth flow via the shared `lfkdsk-auth` Cloudflare Worker (`auth.lfkdsk.org/picg/callback`).
- Adds `initiateGitHubOAuth()` and `consumeOAuthFragment()` helpers in `src/lib/auth.ts` (CSRF-state validated).
- Root page (`src/app/page.tsx`) now detects the OAuth fragment, fetches the GitHub user profile, persists token + user, then routes to `/main`. OAuth errors surface back on `/login` via `?error=`.
- Manual Personal Access Token form is kept as a fallback.

## Why

Until now PicG only supported PAT-based login — users had to generate a token on github.com and paste it. With the shared `lfkdsk-auth` broker now in place across the lfkdsk portfolio, PicG can do a normal "Sign in with GitHub" flow.

## Flow

1. `[LoginOptions]` → `initiateGitHubOAuth()` (saves random `state` to sessionStorage)
2. `https://github.com/login/oauth/authorize` → `https://auth.lfkdsk.org/picg/callback?code=…`
3. Worker exchanges code → 302 to `https://picg.lfkdsk.org/#oauth_token=<tok>&state=<s>`
4. `[page.tsx]` `consumeOAuthFragment()` → fetch `/user` → `storeAuthData()` → `/main`

The token lives in the URL **fragment**, not the query string, so it stays client-side (no Referer / access-log leak).

## Reviewer notes

- Depends on the `lfkdsk-auth` PR that registers `picg` in `PROJECT_ORIGINS`. That Worker must be redeployed before this lands in prod, otherwise `/picg/callback` returns 400.
- `client_id` (`Ov23liCg29llKxJ7b0jv`) is intentionally public — only the Worker holds the secret.
- Scope requested is `repo` (matches what existing PAT users need for upload/delete).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)