### PR TITLE
fix: restore avatar/Settings menu after OAuth login

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,10 @@ export default function HomePage() {
           if (!resp.ok) throw new Error('Failed to fetch GitHub user');
           const user = await resp.json();
           storeAuthData(oauthResult.token, user);
-          router.push('/main');
+          // Hard navigation so the persistent Navbar re-mounts and picks up
+          // the freshly-stored gh_user — soft routing keeps the old (no-user)
+          // instance alive and the avatar/Settings menu stays hidden.
+          window.location.replace('/main');
         } catch {
           router.push('/login?error=Failed+to+fetch+GitHub+user+profile');
         }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,8 +1,10 @@
 'use client';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import ThemeToggle from './ThemeToggle';
 import { useEffect, useRef, useState } from 'react';
 import { getGitHubToken, logout } from '@/lib/github';
+import { getStoredUser } from '@/lib/auth';
 
 type GhUser = { avatar_url: string; login: string };
 
@@ -10,10 +12,24 @@ export default function Navbar() {
   const [user, setUser] = useState<GhUser | null>(null);
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  // Navbar lives in the root layout and survives SPA navigation, so re-run
+  // this effect on every route change — otherwise OAuth login (which only
+  // writes the token after the initial mount, then router.push('/main'))
+  // never refreshes the user state.
+  const pathname = usePathname();
 
   useEffect(() => {
+    const stored = getStoredUser();
+    if (stored?.avatar_url) {
+      setUser({ avatar_url: stored.avatar_url, login: stored.login });
+      return;
+    }
+
     const token = getGitHubToken();
-    if (!token) return;
+    if (!token) {
+      setUser(null);
+      return;
+    }
     fetch('https://api.github.com/user', {
       headers: { Authorization: `token ${token}`, Accept: 'application/vnd.github+json' }
     })
@@ -22,7 +38,7 @@ export default function Navbar() {
         if (data?.avatar_url) setUser({ avatar_url: data.avatar_url, login: data.login });
       })
       .catch(() => {});
-  }, []);
+  }, [pathname]);
 
   useEffect(() => {
     const onDoc = (e: MouseEvent) => {


### PR DESCRIPTION
## 问题

OAuth 登录上线（#71a41a4）后，登录成功跳转到 `/main` 时导航栏的头像和「设置」入口都不见了。

## 根因

`Navbar` 在根 `layout.tsx` 里渲染，SPA 软跳转不会触发它重新挂载。OAuth 流程是：

1. 浏览器从 GitHub 跳回 `/#oauth_token=…`，layout + Navbar 挂载，此时 `gh_token` 还没写入 → `Navbar` 的 `useEffect` 提前跑了一次，`user` 保持 `null`。
2. `/page.tsx` 随后消费 fragment、`storeAuthData()` 写入 `gh_token` + `gh_user`，然后 `router.push('/main')`。
3. 软跳转不会重挂载 Navbar，那个 `useEffect` 也不会再跑 → 头像和「设置」菜单整块被 `{user ? … : null}` 隐藏。

之前 `/login/token` 走的是 `window.location.replace('/main')` 整页刷新，所以没暴露这个问题。

## 修复

- `Navbar` 用 `usePathname()` 作为 effect 依赖，路由变化时重新读取用户信息。
- 优先用 OAuth 已经存进 `localStorage` 的 `gh_user`（`getStoredUser()`），省掉一次多余的 `/user` 请求；token-only 登录路径仍然回退到 GitHub API。

## Test plan

- [ ] OAuth 登录后 `/main` 上能看到头像，点击展开有「设置」「退出登录」。
- [ ] Token 表单登录路径仍正常显示头像。
- [ ] 登出后头像消失。

https://claude.ai/code/session_019U4iHY3TQb76iwfBgz4gmu

---
_Generated by [Claude Code](https://claude.ai/code/session_019U4iHY3TQb76iwfBgz4gmu)_