### PR TITLE
feat: annual-summary monthly photo picker

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,16 @@ const nextConfig = {
       '@': require('path').resolve(__dirname, 'src'),
     };
 
+    // sql.js 在浏览器端不需要 Node 内置模块，需要 stub 掉
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...(config.resolve.fallback || {}),
+        fs: false,
+        path: false,
+        crypto: false,
+      };
+    }
+
     return config;
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "picg",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@lfkdsk/exif-library": "^2.0.3",
         "@types/js-yaml": "^4.0.9",
@@ -15,6 +16,7 @@
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "sql.js": "^1.14.1",
         "styled-jsx": "^5.1.7"
       },
       "devDependencies": {
@@ -24,6 +26,7 @@
         "@types/node": "20.16.10",
         "@types/react": "18.3.9",
         "@types/react-dom": "18.3.0",
+        "@types/sql.js": "^1.4.11",
         "eslint": "8.57.1",
         "eslint-config-next": "14.2.5",
         "jest": "29.7.0",
@@ -1795,6 +1798,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "dev": true
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1939,6 +1948,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
+      "integrity": "sha512-QXIx38p2ZThJaK9vP5ZdqdlRe1FG9I8SmCZOS7FHfB/2qPAjZwkL7/vlfPg6N/oWHuuOaGg/P/IRwfP2W0kWVQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -8933,6 +8952,11 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A=="
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "picg",
   "version": "0.1.0",
   "description": "A modern GitHub-based photo gallery management system",
-  "keywords": ["github", "photo", "gallery", "nextjs", "react", "typescript"],
+  "keywords": [
+    "github",
+    "photo",
+    "gallery",
+    "nextjs",
+    "react",
+    "typescript"
+  ],
   "author": "PicG Contributors",
   "license": "MIT",
   "homepage": "https://github.com/your-username/PicG#readme",
@@ -33,6 +40,7 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "sql.js": "^1.14.1",
     "styled-jsx": "^5.1.7"
   },
   "devDependencies": {
@@ -42,6 +50,7 @@
     "@types/node": "20.16.10",
     "@types/react": "18.3.9",
     "@types/react-dom": "18.3.0",
+    "@types/sql.js": "^1.4.11",
     "eslint": "8.57.1",
     "eslint-config-next": "14.2.5",
     "jest": "29.7.0",

--- a/src/app/gallery/[owner]/[repo]/annual-summary/[year]/page.tsx
+++ b/src/app/gallery/[owner]/[repo]/annual-summary/[year]/page.tsx
@@ -1,0 +1,371 @@
+'use client';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import AuthGuard from '@/components/AuthGuard';
+import { fetchGitHubFile, getGitHubToken } from '@/lib/github';
+import { openGalleryDb } from '@/lib/sqlite';
+import {
+  AnnualSummary,
+  CandidatePhoto,
+  GalleryUrlConfig,
+  MonthKey,
+  MonthlyCandidates,
+  fetchSummary,
+  listMonthlyCandidates,
+  parseGalleryConfig,
+  saveSummary,
+  thumbnailUrlFor,
+} from '@/lib/annualSummary';
+
+const MONTH_LABEL: Record<MonthKey, string> = {
+  '01': '一月',
+  '02': '二月',
+  '03': '三月',
+  '04': '四月',
+  '05': '五月',
+  '06': '六月',
+  '07': '七月',
+  '08': '八月',
+  '09': '九月',
+  '10': '十月',
+  '11': '十一月',
+  '12': '十二月',
+};
+
+const ALL_MONTHS: MonthKey[] = [
+  '01', '02', '03', '04', '05', '06',
+  '07', '08', '09', '10', '11', '12',
+];
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | {
+      kind: 'ready';
+      cfg: GalleryUrlConfig;
+      candidates: MonthlyCandidates;
+      months: MonthKey[];
+    };
+
+const draftKey = (owner: string, repo: string, year: string) =>
+  `annualSummaryDraft:${owner}/${repo}:${year}`;
+
+export default function AnnualSummaryPicker() {
+  const params = useParams();
+  const router = useRouter();
+  const owner = params.owner as string;
+  const repo = params.repo as string;
+  const year = params.year as string;
+
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+  const [stepIdx, setStepIdx] = useState(0);
+  const [selections, setSelections] = useState<AnnualSummary>({});
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = getGitHubToken();
+        if (!token) throw new Error('未登录');
+        const configText = await fetchGitHubFile(token, owner, repo, 'CONFIG.yml');
+        const cfg = parseGalleryConfig(configText);
+        const db = await openGalleryDb(cfg.siteUrl);
+        const candidates = listMonthlyCandidates(db, year);
+        const months = ALL_MONTHS.filter((m) => (candidates[m]?.length ?? 0) > 0);
+        if (cancelled) return;
+
+        const existing = await fetchSummary(token, owner, repo, year);
+        const draftRaw = sessionStorage.getItem(draftKey(owner, repo, year));
+        let initial: AnnualSummary = {};
+        if (draftRaw) {
+          try {
+            initial = JSON.parse(draftRaw);
+          } catch {
+            initial = {};
+          }
+        } else if (existing) {
+          initial = existing;
+        }
+        if (cancelled) return;
+        setSelections(initial);
+        setState({ kind: 'ready', cfg, candidates, months });
+        setStepIdx(0);
+      } catch (err) {
+        if (cancelled) return;
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : '加载失败',
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [owner, repo, year]);
+
+  useEffect(() => {
+    if (state.kind !== 'ready') return;
+    sessionStorage.setItem(draftKey(owner, repo, year), JSON.stringify(selections));
+  }, [selections, state.kind, owner, repo, year]);
+
+  const months = state.kind === 'ready' ? state.months : [];
+  const currentMonth = months[stepIdx];
+  const candidatesForMonth: CandidatePhoto[] =
+    state.kind === 'ready' && currentMonth ? state.candidates[currentMonth] ?? [] : [];
+
+  const completedCount = useMemo(
+    () => months.filter((m) => selections[m]).length,
+    [months, selections],
+  );
+
+  const onPick = (path: string) => {
+    if (!currentMonth) return;
+    setSelections((s) => ({ ...s, [currentMonth]: path }));
+  };
+
+  const onSkip = () => {
+    if (!currentMonth) return;
+    setSelections((s) => {
+      const next = { ...s };
+      delete next[currentMonth];
+      return next;
+    });
+    if (stepIdx < months.length - 1) setStepIdx((i) => i + 1);
+  };
+
+  const onPrev = () => {
+    if (stepIdx > 0) setStepIdx((i) => i - 1);
+  };
+
+  const onNext = () => {
+    if (stepIdx < months.length - 1) setStepIdx((i) => i + 1);
+  };
+
+  const onSubmit = async () => {
+    setSaveError(null);
+    setSaving(true);
+    try {
+      const token = getGitHubToken();
+      if (!token) throw new Error('未登录');
+      await saveSummary(token, owner, repo, year, selections);
+      sessionStorage.removeItem(draftKey(owner, repo, year));
+      router.push(`/gallery/${owner}/${repo}`);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : '保存失败');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const isLastStep = stepIdx === months.length - 1;
+
+  return (
+    <AuthGuard>
+      <div className="container">
+        <header className="header">
+          <Link href={`/gallery/${owner}/${repo}`} className="back-link">
+            ← 返回 {owner}/{repo}
+          </Link>
+          <h1 className="title">{year} 年度精选</h1>
+          <p className="subtitle">
+            {state.kind === 'ready'
+              ? `共 ${months.length} 个有图月份，已选 ${completedCount} / ${months.length}`
+              : '加载中…'}
+          </p>
+        </header>
+
+        {state.kind === 'loading' && <div className="info">读取 sqlite.db 中…</div>}
+        {state.kind === 'error' && <div className="error">错误：{state.message}</div>}
+
+        {state.kind === 'ready' && months.length === 0 && (
+          <div className="info">该年度数据库里没有照片。</div>
+        )}
+
+        {state.kind === 'ready' && currentMonth && (
+          <>
+            <nav className="month-tabs">
+              {months.map((m, i) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={`tab ${i === stepIdx ? 'active' : ''} ${selections[m] ? 'done' : ''}`}
+                  onClick={() => setStepIdx(i)}
+                >
+                  {MONTH_LABEL[m]}
+                  {selections[m] && <span className="dot" />}
+                </button>
+              ))}
+            </nav>
+
+            <div className="step-info">
+              <h2>
+                {MONTH_LABEL[currentMonth]} · {candidatesForMonth.length} 张候选
+              </h2>
+              {selections[currentMonth] && (
+                <p className="picked">
+                  已选：<code>{selections[currentMonth]}</code>
+                </p>
+              )}
+            </div>
+
+            <div className="grid">
+              {candidatesForMonth.map((p) => {
+                const picked = selections[currentMonth] === p.path;
+                return (
+                  <button
+                    key={p.path}
+                    type="button"
+                    className={`thumb ${picked ? 'picked' : ''}`}
+                    onClick={() => onPick(p.path)}
+                  >
+                    <img
+                      src={thumbnailUrlFor(state.cfg, p.path)}
+                      alt={p.path}
+                      loading="lazy"
+                      crossOrigin="anonymous"
+                    />
+                    <div className="meta">
+                      <span className="date">{p.date}</span>
+                      <span className="path" title={p.path}>{p.path}</span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="actions">
+              <button
+                type="button"
+                className="btn ghost"
+                onClick={onPrev}
+                disabled={stepIdx === 0 || saving}
+              >
+                上一月
+              </button>
+              <button type="button" className="btn ghost" onClick={onSkip} disabled={saving}>
+                清除并跳过
+              </button>
+              {!isLastStep ? (
+                <button type="button" className="btn primary" onClick={onNext} disabled={saving}>
+                  下一月
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="btn primary"
+                  onClick={onSubmit}
+                  disabled={saving || completedCount === 0}
+                >
+                  {saving ? '保存中…' : `保存到 .analysis/annual-summary/${year}.json`}
+                </button>
+              )}
+            </div>
+            {saveError && <div className="error">保存失败：{saveError}</div>}
+          </>
+        )}
+
+        <style jsx>{`
+          .container { width: min(1200px, 94vw); margin: 0 auto; padding: 20px; }
+          .header { margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
+          .back-link { color: var(--primary); text-decoration: none; font-size: 14px; }
+          .title { font-size: 26px; font-weight: 700; margin: 8px 0 4px; color: var(--text); }
+          .subtitle { color: var(--text-secondary); margin: 0; font-size: 14px; }
+          .info { padding: 24px; text-align: center; color: var(--text-secondary); }
+          .error { padding: 12px; color: #ef4444; }
+          .month-tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+            margin-bottom: 16px;
+            padding: 8px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--surface);
+          }
+          .tab {
+            position: relative;
+            background: transparent;
+            border: 1px solid transparent;
+            color: var(--text-secondary);
+            padding: 6px 12px;
+            border-radius: 8px;
+            font-size: 13px;
+            cursor: pointer;
+            transition: all 0.15s ease;
+          }
+          .tab:hover { color: var(--text); }
+          .tab.active {
+            background: var(--primary);
+            color: white;
+            border-color: var(--primary);
+          }
+          .tab.done { color: var(--text); }
+          .tab .dot {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: #10b981;
+            margin-left: 6px;
+            vertical-align: middle;
+          }
+          .step-info { margin-bottom: 12px; }
+          .step-info h2 { font-size: 18px; margin: 0 0 4px; color: var(--text); }
+          .picked { font-size: 13px; color: var(--text-secondary); margin: 0; }
+          .picked code { background: var(--surface); padding: 2px 6px; border-radius: 4px; }
+          .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 12px;
+            margin-bottom: 20px;
+          }
+          .thumb {
+            background: var(--surface);
+            border: 2px solid var(--border);
+            border-radius: 12px;
+            padding: 0;
+            overflow: hidden;
+            cursor: pointer;
+            text-align: left;
+            transition: all 0.2s ease;
+          }
+          .thumb:hover { transform: translateY(-2px); border-color: color-mix(in srgb, var(--primary), transparent 50%); }
+          .thumb.picked { border-color: var(--primary); box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary), transparent 80%); }
+          .thumb img { display: block; width: 100%; aspect-ratio: 4/3; object-fit: cover; background: var(--border); }
+          .meta { padding: 8px 10px; display: flex; flex-direction: column; gap: 2px; font-size: 12px; }
+          .date { color: var(--text-secondary); }
+          .path { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+          .actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+            padding-top: 12px;
+            border-top: 1px solid var(--border);
+            position: sticky;
+            bottom: 0;
+            background: var(--background);
+            padding-bottom: 12px;
+          }
+          .btn {
+            padding: 8px 16px;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            border: 1px solid var(--border);
+            background: var(--surface);
+            color: var(--text);
+            transition: all 0.15s ease;
+          }
+          .btn.primary { background: var(--primary); color: white; border-color: var(--primary); }
+          .btn.primary:hover:not(:disabled) { background: color-mix(in srgb, var(--primary), black 10%); }
+          .btn.ghost:hover:not(:disabled) { color: var(--text); }
+          .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        `}</style>
+      </div>
+    </AuthGuard>
+  );
+}

--- a/src/app/gallery/[owner]/[repo]/page.tsx
+++ b/src/app/gallery/[owner]/[repo]/page.tsx
@@ -5,12 +5,26 @@ import Link from 'next/link';
 import yaml from 'js-yaml';
 import { fetchGitHubFile, updateGitHubFile, getFileSha, getGitHubToken, encodeGitHubPath } from '@/lib/github';
 import AuthGuard from '@/components/AuthGuard';
+import { openGalleryDb } from '@/lib/sqlite';
+import {
+  listYearsWithPhotos,
+  listExistingSummaryYears,
+  parseGalleryConfig,
+} from '@/lib/annualSummary';
 
 type Config = {
   thumbnail_url: string;
   base_url: string;
   backup_base_url: string;
   backup_thumbnail_url: string;
+  url?: string;
+};
+
+type SummaryStatus = {
+  loading: boolean;
+  pendingYears: string[];
+  filledYears: string[];
+  error: string | null;
 };
 
 type Album = {
@@ -37,6 +51,12 @@ export default function GalleryPage() {
   const [isConfigEditMode, setIsConfigEditMode] = useState(false);
   const [configContent, setConfigContent] = useState<string>('');
   const [savingConfig, setSavingConfig] = useState(false);
+  const [summaryStatus, setSummaryStatus] = useState<SummaryStatus>({
+    loading: false,
+    pendingYears: [],
+    filledYears: [],
+    error: null,
+  });
 
 
 
@@ -267,6 +287,44 @@ export default function GalleryPage() {
     }
   }, [owner, repo]);
 
+  useEffect(() => {
+    if (!configContent || !owner || !repo) return;
+    let cancelled = false;
+    setSummaryStatus((s) => ({ ...s, loading: true, error: null }));
+    (async () => {
+      try {
+        const cfg = parseGalleryConfig(configContent);
+        const token = getGitHubToken();
+        if (!token) throw new Error('No token');
+        const [db, filledYears] = await Promise.all([
+          openGalleryDb(cfg.siteUrl),
+          listExistingSummaryYears(token, owner, repo),
+        ]);
+        if (cancelled) return;
+        const yearsWithPhotos = listYearsWithPhotos(db);
+        const filledSet = new Set(filledYears);
+        const pendingYears = yearsWithPhotos.filter((y) => !filledSet.has(y));
+        setSummaryStatus({
+          loading: false,
+          pendingYears,
+          filledYears: yearsWithPhotos.filter((y) => filledSet.has(y)),
+          error: null,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setSummaryStatus({
+          loading: false,
+          pendingYears: [],
+          filledYears: [],
+          error: err instanceof Error ? err.message : '加载年度精选状态失败',
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [configContent, owner, repo]);
+
   if (loading) {
     return (
       <div className="container">
@@ -372,6 +430,47 @@ export default function GalleryPage() {
           </div>
         </div>
       ) : (
+        <>
+        {(summaryStatus.pendingYears.length > 0 || summaryStatus.loading || summaryStatus.error) && (
+          <section className="summary-section">
+            <div className="summary-header">
+              <h2 className="summary-title">年度精选 · 每月印象</h2>
+              <p className="summary-desc">
+                为每年挑选每月一张代表照片，主题站会优先使用你选中的图，没填则随机。
+              </p>
+            </div>
+            {summaryStatus.loading && (
+              <div className="summary-loading">读取 sqlite.db 中…</div>
+            )}
+            {summaryStatus.error && !summaryStatus.loading && (
+              <div className="summary-error">无法加载年度精选状态：{summaryStatus.error}</div>
+            )}
+            {!summaryStatus.loading && summaryStatus.pendingYears.length > 0 && (
+              <div className="summary-grid">
+                {summaryStatus.pendingYears.map((y) => (
+                  <Link
+                    key={y}
+                    href={`/gallery/${owner}/${repo}/annual-summary/${y}`}
+                    className="summary-card pending"
+                  >
+                    <span className="summary-year">{y}</span>
+                    <span className="summary-state">待填写 →</span>
+                  </Link>
+                ))}
+                {summaryStatus.filledYears.map((y) => (
+                  <Link
+                    key={y}
+                    href={`/gallery/${owner}/${repo}/annual-summary/${y}`}
+                    className="summary-card filled"
+                  >
+                    <span className="summary-year">{y}</span>
+                    <span className="summary-state">已填写 · 编辑</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
         <div className="albums-grid">
         {albums.map((album) => (
           <Link 
@@ -448,6 +547,7 @@ export default function GalleryPage() {
           </Link>
         ))}
         </div>
+        </>
       )}
 
       <style jsx>{`
@@ -685,6 +785,59 @@ export default function GalleryPage() {
           opacity: 0.6;
           cursor: not-allowed;
         }
+        .summary-section {
+          margin-bottom: 28px;
+          padding: 20px;
+          border: 1px solid color-mix(in srgb, var(--text), transparent 88%);
+          border-radius: 16px;
+          background: color-mix(in srgb, var(--surface), transparent 30%);
+        }
+        .summary-header { margin-bottom: 12px; }
+        .summary-title { font-size: 18px; font-weight: 700; margin: 0 0 4px; color: var(--text); }
+        .summary-desc { color: var(--text-secondary); font-size: 13px; margin: 0; }
+        .summary-loading, .summary-error {
+          font-size: 13px;
+          color: var(--text-secondary);
+          padding: 8px 0;
+        }
+        .summary-error { color: #ef4444; }
+        .summary-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+          gap: 10px;
+          margin-top: 10px;
+        }
+        .summary-card {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          padding: 12px 14px;
+          border-radius: 10px;
+          text-decoration: none;
+          font-size: 14px;
+          transition: all 0.2s ease;
+          border: 1px solid transparent;
+        }
+        .summary-card.pending {
+          background: color-mix(in srgb, var(--primary), transparent 88%);
+          color: var(--primary);
+          border-color: color-mix(in srgb, var(--primary), transparent 60%);
+        }
+        .summary-card.pending:hover {
+          background: color-mix(in srgb, var(--primary), transparent 75%);
+          transform: translateY(-1px);
+        }
+        .summary-card.filled {
+          background: var(--surface);
+          color: var(--text-secondary);
+          border-color: var(--border);
+        }
+        .summary-card.filled:hover {
+          color: var(--text);
+          border-color: color-mix(in srgb, var(--text), transparent 70%);
+        }
+        .summary-year { font-weight: 700; font-size: 16px; }
+        .summary-state { font-size: 12px; }
       `}</style>
       </div>
     </AuthGuard>

--- a/src/lib/annualSummary.ts
+++ b/src/lib/annualSummary.ts
@@ -1,0 +1,153 @@
+import yaml from 'js-yaml';
+import type { Database } from 'sql.js';
+import {
+  fetchGitHubFile,
+  getFileSha,
+  getRepoContents,
+  updateGitHubFile,
+} from '@/lib/github';
+
+export const SUMMARY_DIR = '.analysis/annual-summary';
+
+export type MonthKey =
+  | '01' | '02' | '03' | '04' | '05' | '06'
+  | '07' | '08' | '09' | '10' | '11' | '12';
+
+export type AnnualSummary = Partial<Record<MonthKey, string>>;
+
+export type CandidatePhoto = {
+  path: string;
+  name: string;
+  date: string;
+};
+
+export type MonthlyCandidates = Partial<Record<MonthKey, CandidatePhoto[]>>;
+
+export type GalleryUrlConfig = {
+  siteUrl: string;
+  thumbnailUrl: string;
+  baseUrl: string;
+  backupThumbnailUrl?: string;
+  backupBaseUrl?: string;
+};
+
+export function parseGalleryConfig(yamlText: string): GalleryUrlConfig {
+  const parsed = yaml.load(yamlText, { schema: yaml.CORE_SCHEMA, json: true }) as Record<
+    string,
+    unknown
+  >;
+  const siteUrl = String(parsed?.url ?? '').replace(/\/+$/, '');
+  const thumbnailUrl = String(parsed?.thumbnail_url ?? '');
+  const baseUrl = String(parsed?.base_url ?? '');
+  if (!siteUrl) {
+    throw new Error('CONFIG.yml 缺少 url 字段，无法定位 sqlite.db');
+  }
+  return {
+    siteUrl,
+    thumbnailUrl,
+    baseUrl,
+    backupThumbnailUrl: parsed?.backup_thumbnail_url ? String(parsed.backup_thumbnail_url) : undefined,
+    backupBaseUrl: parsed?.backup_base_url ? String(parsed.backup_base_url) : undefined,
+  };
+}
+
+export function listYearsWithPhotos(db: Database): string[] {
+  const res = db.exec(
+    `SELECT DISTINCT strftime('%Y', e.date) AS y
+       FROM photo p
+       JOIN exifdata e ON p.exif_data_id = e.id
+      WHERE e.date IS NOT NULL
+      ORDER BY y DESC`,
+  );
+  if (!res.length) return [];
+  return res[0].values
+    .map((row) => row[0])
+    .filter((v): v is string => typeof v === 'string' && v.length === 4);
+}
+
+export function listMonthlyCandidates(db: Database, year: string): MonthlyCandidates {
+  const res = db.exec(
+    `SELECT strftime('%m', e.date) AS m,
+            p.path,
+            p.name,
+            strftime('%Y-%m-%d', e.date) AS d
+       FROM photo p
+       JOIN exifdata e ON p.exif_data_id = e.id
+      WHERE strftime('%Y', e.date) = $year
+        AND e.date IS NOT NULL
+      ORDER BY e.date ASC`,
+    { $year: year },
+  );
+  const out: MonthlyCandidates = {};
+  if (!res.length) return out;
+  for (const [m, path, name, date] of res[0].values) {
+    if (typeof m !== 'string' || typeof path !== 'string') continue;
+    const key = m as MonthKey;
+    const list = out[key] ?? (out[key] = []);
+    list.push({
+      path,
+      name: typeof name === 'string' ? name : path,
+      date: typeof date === 'string' ? date : '',
+    });
+  }
+  return out;
+}
+
+export function thumbnailUrlFor(cfg: GalleryUrlConfig, photoPath: string): string {
+  const base = (cfg.thumbnailUrl || cfg.backupThumbnailUrl || cfg.baseUrl || '').replace(/\/+$/, '');
+  const webpPath = photoPath.replace(/\.\w+$/, '.webp');
+  const encoded = webpPath.split('/').map((part) => encodeURIComponent(part)).join('/');
+  return `${base}/${encoded}`;
+}
+
+export async function listExistingSummaryYears(
+  token: string,
+  owner: string,
+  repo: string,
+): Promise<string[]> {
+  const items = await getRepoContents(token, owner, repo, SUMMARY_DIR);
+  return items
+    .filter((item: any) => item?.type === 'file' && /^\d{4}\.json$/.test(item.name))
+    .map((item: any) => item.name.replace(/\.json$/, ''));
+}
+
+export async function fetchSummary(
+  token: string,
+  owner: string,
+  repo: string,
+  year: string,
+): Promise<AnnualSummary | null> {
+  try {
+    const text = await fetchGitHubFile(token, owner, repo, `${SUMMARY_DIR}/${year}.json`);
+    return JSON.parse(text) as AnnualSummary;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSummary(
+  token: string,
+  owner: string,
+  repo: string,
+  year: string,
+  summary: AnnualSummary,
+  message?: string,
+): Promise<void> {
+  const path = `${SUMMARY_DIR}/${year}.json`;
+  const sha = await getFileSha(token, owner, repo, path);
+  const ordered: AnnualSummary = {};
+  (Object.keys(summary).sort() as MonthKey[]).forEach((k) => {
+    const v = summary[k];
+    if (v) ordered[k] = v;
+  });
+  const content = JSON.stringify(ordered, null, 2) + '\n';
+  await updateGitHubFile(
+    token,
+    owner,
+    repo,
+    path,
+    content,
+    message ?? `Update annual-summary ${year} via PicG`,
+    sha,
+  );
+}

--- a/src/lib/sqlite.ts
+++ b/src/lib/sqlite.ts
@@ -1,0 +1,41 @@
+import type { Database, SqlJsStatic } from 'sql.js';
+
+const SQL_JS_VERSION = '1.14.1';
+const SQL_WASM_URL = `https://cdn.jsdelivr.net/npm/sql.js@${SQL_JS_VERSION}/dist/sql-wasm.wasm`;
+
+let sqlJsPromise: Promise<SqlJsStatic> | null = null;
+
+async function getSqlJs(): Promise<SqlJsStatic> {
+  if (!sqlJsPromise) {
+    sqlJsPromise = (async () => {
+      const initSqlJs = (await import('sql.js')).default;
+      return initSqlJs({ locateFile: () => SQL_WASM_URL });
+    })();
+  }
+  return sqlJsPromise;
+}
+
+const dbCache = new Map<string, Promise<Database>>();
+
+export async function openGalleryDb(siteUrl: string): Promise<Database> {
+  const key = siteUrl.replace(/\/+$/, '');
+  let promise = dbCache.get(key);
+  if (!promise) {
+    promise = (async () => {
+      const SQL = await getSqlJs();
+      const res = await fetch(`${key}/sqlite.db`, { cache: 'no-cache' });
+      if (!res.ok) {
+        throw new Error(`Failed to fetch sqlite.db from ${key}: ${res.status} ${res.statusText}`);
+      }
+      const buf = await res.arrayBuffer();
+      return new SQL.Database(new Uint8Array(buf));
+    })();
+    dbCache.set(key, promise);
+    promise.catch(() => dbCache.delete(key));
+  }
+  return promise;
+}
+
+export function clearDbCache(): void {
+  dbCache.clear();
+}


### PR DESCRIPTION
## Summary
- Adds a per-year wizard that lets users pick one photo per month and persists the result to `gallery/.analysis/annual-summary/<year>.json` via the GitHub API.
- Detects pending years on the gallery repo page by diffing the sqlite year list (loaded from gh-pages via sql.js) against existing JSONs, and surfaces a deep-linked "待填写" card section.
- Companion changes live in `album_template/build.py` (copies the JSON into `public/annual-summary/`) and `hexo-theme-type/layout/summary.ejs` (prefers the JSON over the existing `ORDER BY RANDOM()` SQL when present, falls back when absent). Those are separate repos and not included in this PR.

## What changed in this repo
- `src/lib/sqlite.ts` — caches a sql.js `Database` per gallery site URL; wasm fetched from jsDelivr (`sql.js@1.14.1`).
- `src/lib/annualSummary.ts` — parses CONFIG.yml, queries `photo + exifdata` for years and per-month candidates, reads/writes the JSON via the existing `fetchGitHubFile` / `updateGitHubFile` helpers, derives thumbnails via `thumbnail_url` (with `.webp` rewrite).
- `src/app/gallery/[owner]/[repo]/page.tsx` — kicks off the sqlite + JSON discovery once `CONFIG.yml` is loaded, renders a "年度精选" section above the albums grid with pending/filled cards.
- `src/app/gallery/[owner]/[repo]/annual-summary/[year]/page.tsx` — month-by-month picker (tabs + grid + sticky actions), sessionStorage draft, prefills from existing JSON when re-entering, final POST writes the JSON.
- `next.config.js` — stubs `fs`/`path`/`crypto` for the client bundle so sql.js's Node fallbacks don't break webpack.
- Adds `sql.js` runtime dep + `@types/sql.js`.

## Notes for reviewers
- JSON shape is `{ "MM": "<album>/<file>.<ext>" }` — exactly the value of `photo.path` from the gallery sqlite, so the theme can do `thumbnail_url + path` and stay consistent with the SQL path.
- Months with zero candidates are silently skipped (no force-pick UI).
- sqlite.db is fetched from `<CONFIG.url>/sqlite.db` — this assumes the deployed site allows cross-origin GET for the .db. GitHub Pages does by default.
- `tsc --noEmit` passes locally. `next build` / `next lint` could not run here (local Node 16 < 18.17 floor); please verify in CI / a Node 18+ environment.

## Test plan
- [ ] Open `/gallery/<owner>/<repo>` for a repo whose gallery has photos but no `.analysis/annual-summary/`; the "年度精选" section shows one "待填写" card per year present in the sqlite EXIF data.
- [ ] Enter the picker for one year, navigate through tabs, pick a photo per month, submit; verify `.analysis/annual-summary/<year>.json` is created with sorted month keys and the expected `<album>/<file>.<ext>` values.
- [ ] Re-enter the picker for the same year; previous selections are prefilled and editable.
- [ ] Verify that closing/reopening the tab mid-flow restores the draft from `sessionStorage`.
- [ ] After running the companion `album_template/build.py` patch, the deployed site's `summary?year=...` page renders the JSON-driven monthly photos; deleting the JSON falls back to the random SQL behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)