### PR TITLE
fix(auth): clear imported galleries and drafts on logout

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -55,21 +55,40 @@ export async function validateCurrentToken(): Promise<boolean> {
 // 清理所有token相关的存储
 export function clearGitHubToken(): void {
   if (typeof window !== 'undefined') {
-    // 清除localStorage
-    localStorage.removeItem('gh_token');
-    localStorage.removeItem('github_token'); // 兼容旧版本
-    
+    // 清除localStorage 中的 token + 用户态 + 已导入画廊缓存
+    const localKeys = [
+      'gh_token',
+      'github_token', // 兼容旧版本
+      'gh_user',
+      'gh_token_expiry',
+      'pictor_galleries',
+      'pictor_repos_cache',
+    ];
+    localKeys.forEach((k) => localStorage.removeItem(k));
+
+    // 清除任何以 annualSummaryDraft: 开头的草稿（每个 owner/repo/year 一条）
+    try {
+      Object.keys(localStorage)
+        .filter((k) => k.startsWith('annualSummaryDraft:'))
+        .forEach((k) => localStorage.removeItem(k));
+    } catch { /* ignore */ }
+
     // 清除所有相关的cookie
     const cookiesToClear = ['gh_token', 'github_token'];
     cookiesToClear.forEach(cookieName => {
       document.cookie = `${cookieName}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
       document.cookie = `${cookieName}=; Path=/; Domain=${window.location.hostname}; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax`;
     });
-    
-    // 清除sessionStorage中的相关数据
+
+    // 清除sessionStorage中的相关数据 + annual-summary 草稿
     sessionStorage.removeItem('newAlbumForm');
     sessionStorage.removeItem('uploadedFiles');
-    
+    try {
+      Object.keys(sessionStorage)
+        .filter((k) => k.startsWith('annualSummaryDraft:'))
+        .forEach((k) => sessionStorage.removeItem(k));
+    } catch { /* ignore */ }
+
     // 清除其他可能的缓存
     try {
       if ('caches' in window) {


### PR DESCRIPTION
## Summary
After logout, the imported gallery list (`pictor_galleries`) and the cached GitHub repo list (`pictor_repos_cache`) stayed in `localStorage`. The next time anyone hit the home page they saw the previous user's imported galleries — even if those repos belonged to another GitHub account or had since been removed.

`clearGitHubToken()` only stripped `gh_token` plus two sessionStorage keys. This PR widens the wipe to cover everything that's keyed to a specific user / draft.

## Cleared on logout
- `gh_token`, `github_token` (legacy), `gh_user`, `gh_token_expiry`
- `pictor_galleries`, `pictor_repos_cache`
- Any `annualSummaryDraft:*` entries in `localStorage` and `sessionStorage`
- `gh_token` / `github_token` cookies (already cleared)
- Browser caches (already cleared)
- `newAlbumForm`, `uploadedFiles` in `sessionStorage` (already cleared)

## Test plan
- [ ] Sign in, import 1–2 galleries, then log out via the navbar.
- [ ] After redirect to `/login`, open devtools → `localStorage` and confirm `pictor_galleries` and `pictor_repos_cache` are gone.
- [ ] Navigate back to `/main`. The home page shows "未检测到 Token" prompt and an empty grid (no leftover gallery cards).
- [ ] Start an annual-summary draft on a repo, then log out before submitting; reopening the picker after re-login starts fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)