### PR TITLE
fix(desktop): lazy-init bridge so SPA nav doesn't flash "Desktop only"

### DIFF
--- a/src/app/desktop/galleries/[id]/[album]/add/page.tsx
+++ b/src/app/desktop/galleries/[id]/[album]/add/page.tsx
@@ -50,7 +50,7 @@ export default function AddPhotosPage() {
     }
   }, [params?.album]);
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
 

--- a/src/app/desktop/galleries/[id]/[album]/page.tsx
+++ b/src/app/desktop/galleries/[id]/[album]/page.tsx
@@ -122,7 +122,7 @@ export default function AlbumPage() {
     }
   }, [params?.album]);
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
   const [albumMeta, setAlbumMeta] = useState<AlbumMeta | null>(null);

--- a/src/app/desktop/galleries/[id]/annual-summary/[year]/page.tsx
+++ b/src/app/desktop/galleries/[id]/annual-summary/[year]/page.tsx
@@ -56,7 +56,7 @@ export default function AnnualSummaryPicker() {
   const galleryId = params?.id;
   const year = params?.year;
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
   const [candidates, setCandidates] = useState<MonthlyCandidates | null>(null);

--- a/src/app/desktop/galleries/[id]/annual-summary/page.tsx
+++ b/src/app/desktop/galleries/[id]/annual-summary/page.tsx
@@ -27,7 +27,7 @@ export default function AnnualSummaryYearsPage() {
   const params = useParams<{ id: string }>();
   const galleryId = params?.id;
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
   const [entries, setEntries] = useState<YearEntry[] | null>(null);

--- a/src/app/desktop/galleries/[id]/new-album/page.tsx
+++ b/src/app/desktop/galleries/[id]/new-album/page.tsx
@@ -70,7 +70,7 @@ export default function NewAlbumPage() {
   const params = useParams<{ id: string }>();
   const galleryId = params?.id;
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
 

--- a/src/app/desktop/galleries/[id]/page.tsx
+++ b/src/app/desktop/galleries/[id]/page.tsx
@@ -62,7 +62,7 @@ export default function GalleryDetailPage() {
   const params = useParams<{ id: string }>();
   const id = params?.id;
 
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [gallery, setGallery] = useState<LocalGallery | null>(null);
   const [adapter, setAdapter] = useState<StorageAdapter | null>(null);
   const [defaultBranch, setDefaultBranch] = useState<string | null>(null);

--- a/src/app/desktop/galleries/page.tsx
+++ b/src/app/desktop/galleries/page.tsx
@@ -52,7 +52,11 @@ function cloneUrlFor(fullName: string): string {
 }
 
 export default function GalleriesPage() {
-  const [bridge, setBridge] = useState<PicgBridge | null>(null);
+  // Lazy init reads window.picgBridge synchronously on first render so
+  // SPA navigations don't flash the "Desktop only" gate while a useEffect
+  // catches up. SSR returns null (no window), which still produces a
+  // brief flash on the very first cold load — that's a one-time hit.
+  const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
   const [token, setToken] = useState<string | null>(null);
   const [galleries, setGalleries] = useState<LocalGallery[]>([]);
   const [cloning, setCloning] = useState<
@@ -65,6 +69,7 @@ export default function GalleriesPage() {
   const [filter, setFilter] = useState('');
 
   useEffect(() => {
+    // Re-read after hydration so SSR's null doesn't stick. Cheap.
     setBridge(getPicgBridge());
     setToken(getGitHubToken());
   }, []);


### PR DESCRIPTION
## Symptom
Click between desktop pages quickly → the new page briefly shows the prominent **"Desktop only"** placeholder before the real content appears.

## Cause
\`\`\`tsx
const [bridge, setBridge] = useState<PicgBridge | null>(null);
useEffect(() => {
  setBridge(getPicgBridge());
}, []);
\`\`\`

First render guarantees \`bridge=null\` → guard renders "Desktop only". \`useEffect\` catches up on the next tick. On a slow mount (or a chain of fast clicks), that null-frame is visible.

## Fix
\`getPicgBridge()\` is already SSR-safe — returns \`null\` when there's no \`window\`, otherwise reads \`window.picgBridge\` synchronously. So we can lazy-init:

\`\`\`tsx
const [bridge, setBridge] = useState<PicgBridge | null>(() => getPicgBridge());
\`\`\`

SPA navs skip SSR → first render has the real bridge → no flash.

The follow-up \`useEffect(() => setBridge(getPicgBridge()))\` stays as a hydration safety net for the cold-start SSR path (server renders null, client re-confirms after hydration).

The login pages already had this pattern; this PR applies it to the 7 pages that didn't.

## Test plan
- [ ] Click between gallery list ↔ gallery detail ↔ album detail rapidly — no "Desktop only" flash
- [ ] Cold-start the app — first page may still flash briefly (SSR limitation), but subsequent navs are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)