### PR TITLE
feat(desktop): compare original vs compressed before upload (+ lossless size fix, icon build fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "fetch:git": "node scripts/fetch-dugite-native.js",
     "fetch:git:all": "node scripts/fetch-dugite-native.js --all",
     "postinstall": "node scripts/fetch-dugite-native.js || true",
+    "build:icon": "node scripts/build-icon.js",
     "electron:build": "tsc -p electron",
     "electron:start": "electron electron/dist/electron/main.js",
     "electron:dev": "node scripts/electron-dev.js",
     "next:build:packaging": "PICG_PACKAGING=1 next build && node scripts/stage-standalone.js",
-    "pack:dir": "npm run fetch:git:all && npm run electron:build && npm run next:build:packaging && electron-builder --dir",
-    "dist:mac": "npm run fetch:git:all && npm run electron:build && npm run next:build:packaging && electron-builder --mac"
+    "pack:dir": "npm run build:icon && npm run fetch:git:all && npm run electron:build && npm run next:build:packaging && electron-builder --dir",
+    "dist:mac": "npm run build:icon && npm run fetch:git:all && npm run electron:build && npm run next:build:packaging && electron-builder --mac"
   },
   "dependencies": {
     "@lfkdsk/exif-library": "^2.0.3",

--- a/src/app/desktop/galleries/[id]/[album]/add/page.tsx
+++ b/src/app/desktop/galleries/[id]/[album]/add/page.tsx
@@ -16,14 +16,22 @@ import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 import { useCompressIpc } from '@/components/desktop/useCompressIpc';
 import { makePreviewUrl } from '@/components/desktop/makePreview';
 import { fireUndoToast } from '@/components/desktop/UndoToast';
+import {
+  CompressCompareModal,
+  type ComparePhoto,
+  sizeDelta,
+} from '@/components/desktop/CompressCompare';
 
 type PhotoStatus = 'pending' | 'compressing' | 'ready' | 'error';
 
 type Photo = {
   id: string;
   original: File;
-  preview: string;
+  preview: string;       // 480px downsampled thumbnail — grid only
+  originalUrl: string;   // full-res object URL of the original — compare modal
   compressed?: File;
+  compressedUrl?: string;
+  useOriginal?: boolean;
   status: PhotoStatus;
   error?: string;
 };
@@ -65,6 +73,7 @@ export default function AddPhotosPage() {
   const [dragOver, setDragOver] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [compareIdx, setCompareIdx] = useState<number | null>(null);
 
   const inFlightRef = useRef<Set<string>>(new Set());
   const { compress } = useCompressIpc();
@@ -100,9 +109,22 @@ export default function AddPhotosPage() {
 
     compress(next.original)
       .then((compressed) => {
+        // Re-encoding a lossy source losslessly (or even lossy WebP on an
+        // already-small file) can come out LARGER than the original. Default
+        // the per-photo choice to whichever file is smaller so doing nothing
+        // never inflates a photo; the user can override in the compare modal.
+        const compressedUrl = URL.createObjectURL(compressed);
         setPhotos((prev) =>
           prev.map((p) =>
-            p.id === next.id ? { ...p, compressed, status: 'ready' } : p
+            p.id === next.id
+              ? {
+                  ...p,
+                  compressed,
+                  compressedUrl,
+                  useOriginal: compressed.size >= p.original.size,
+                  status: 'ready',
+                }
+              : p
           )
         );
       })
@@ -122,7 +144,11 @@ export default function AddPhotosPage() {
 
   useEffect(() => {
     return () => {
-      photos.forEach((p) => URL.revokeObjectURL(p.preview));
+      photos.forEach((p) => {
+        URL.revokeObjectURL(p.preview);
+        if (p.originalUrl) URL.revokeObjectURL(p.originalUrl);
+        if (p.compressedUrl) URL.revokeObjectURL(p.compressedUrl);
+      });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -138,6 +164,10 @@ export default function AddPhotosPage() {
       id: crypto.randomUUID(),
       original: file,
       preview: '',
+      // Full-res URL straight off the original File — no decode/copy here,
+      // the browser only decodes it when the compare modal shows this photo.
+      // The grid keeps using the cheap 480px `preview` thumbnail.
+      originalUrl: URL.createObjectURL(file),
       status: 'pending',
     }));
     setPhotos((prev) => [...prev, ...items]);
@@ -153,9 +183,20 @@ export default function AddPhotosPage() {
   function removePhoto(id: string) {
     setPhotos((prev) => {
       const photo = prev.find((p) => p.id === id);
-      if (photo) URL.revokeObjectURL(photo.preview);
+      if (photo) {
+        URL.revokeObjectURL(photo.preview);
+        if (photo.originalUrl) URL.revokeObjectURL(photo.originalUrl);
+        if (photo.compressedUrl) URL.revokeObjectURL(photo.compressedUrl);
+      }
       return prev.filter((p) => p.id !== id);
     });
+  }
+
+  // Flip the per-photo upload choice (compressed vs original).
+  function toggleUseOriginal(id: string) {
+    setPhotos((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, useOriginal: !p.useOriginal } : p))
+    );
   }
 
   function onDrop(e: React.DragEvent) {
@@ -183,6 +224,25 @@ export default function AddPhotosPage() {
       ? 1 - totalCompressed / totalOriginal
       : 0;
 
+  // Items the compare modal can step through: only photos whose compress
+  // has landed, in grid order. The modal indexes into this list, so the
+  // thumbnail click resolves its position by id below.
+  const comparePhotos = useMemo<ComparePhoto[]>(
+    () =>
+      photos
+        .filter((p) => p.status === 'ready' && p.compressed)
+        .map((p) => ({
+          id: p.id,
+          name: p.original.name,
+          beforeUrl: p.originalUrl || p.preview,
+          afterUrl: p.compressedUrl ?? '',
+          originalSize: p.original.size,
+          compressedSize: p.compressed!.size,
+          useOriginal: !!p.useOriginal,
+        })),
+    [photos]
+  );
+
   async function handleSubmit() {
     if (!adapter || !gallery || !albumUrl) return;
     if (!ready) {
@@ -205,14 +265,19 @@ export default function AddPhotosPage() {
 
       const fileEntries: BatchFile[] = [];
       for (const p of photos) {
-        if (!p.compressed) continue;
-        if (existingNames.has(p.compressed.name)) {
-          duplicates.push(p.compressed.name);
+        // Upload the variant the user chose. Default (set at compress time)
+        // is whichever is smaller, so the original wins when the WebP encode
+        // came out larger. Using the original keeps its source extension.
+        const chosen = p.useOriginal ? p.original : p.compressed;
+        if (!chosen) continue;
+        const chosenName = p.useOriginal ? p.original.name : p.compressed!.name;
+        if (existingNames.has(chosenName)) {
+          duplicates.push(chosenName);
           continue;
         }
-        const bytes = new Uint8Array(await p.compressed.arrayBuffer());
+        const bytes = new Uint8Array(await chosen.arrayBuffer());
         fileEntries.push({
-          path: `${albumUrl}/${p.compressed.name}`,
+          path: `${albumUrl}/${chosenName}`,
           content: bytes,
         });
       }
@@ -324,30 +389,58 @@ export default function AddPhotosPage() {
 
           {photos.length > 0 && (
             <ul className="photos">
-              {photos.map((p) => (
-                <li key={p.id}>
-                  <div className="picg-thumb">
-                    <img src={p.preview} alt="" className="photo-preview" />
-                    {p.status === 'pending' && <span className="state pending">queued</span>}
-                    {p.status === 'compressing' && <span className="state compressing">compressing…</span>}
-                    {p.status === 'error' && <span className="state errored">{p.error ?? 'error'}</span>}
-                    {p.status === 'ready' && p.compressed && (
-                      <span className="state ready">
-                        {formatBytes(p.original.size)} → {formatBytes(p.compressed.size)}
-                      </span>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    className="remove"
-                    onClick={() => removePhoto(p.id)}
-                    disabled={submitting}
-                    aria-label="Remove photo"
-                  >
-                    ✕
-                  </button>
-                </li>
-              ))}
+              {photos.map((p) => {
+                const ready = p.status === 'ready' && p.compressed;
+                const delta = ready
+                  ? sizeDelta(p.original.size, p.compressed!.size)
+                  : null;
+                const openCompare = () => {
+                  const i = comparePhotos.findIndex((c) => c.id === p.id);
+                  if (i >= 0) setCompareIdx(i);
+                };
+                return (
+                  <li key={p.id}>
+                    <div
+                      className={`picg-thumb ${ready ? 'is-clickable' : ''}`}
+                      onClick={ready ? openCompare : undefined}
+                      role={ready ? 'button' : undefined}
+                      tabIndex={ready ? 0 : undefined}
+                      onKeyDown={
+                        ready
+                          ? (e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                openCompare();
+                              }
+                            }
+                          : undefined
+                      }
+                      aria-label={ready ? `Compare ${p.original.name}` : undefined}
+                    >
+                      <img src={p.preview} alt="" className="photo-preview" />
+                      {p.status === 'pending' && <span className="state pending">queued</span>}
+                      {p.status === 'compressing' && <span className="state compressing">compressing…</span>}
+                      {p.status === 'error' && <span className="state errored">{p.error ?? 'error'}</span>}
+                      {ready && delta && (
+                        <span className={`state ready ${delta.bigger ? 'is-bigger' : ''}`}>
+                          {formatBytes(p.original.size)} → {formatBytes(p.compressed!.size)}
+                          {' · '}
+                          {delta.label}
+                        </span>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className="remove"
+                      onClick={() => removePhoto(p.id)}
+                      disabled={submitting}
+                      aria-label="Remove photo"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </section>
@@ -373,6 +466,16 @@ export default function AddPhotosPage() {
           )}
         </div>
       </main>
+
+      {compareIdx != null && (
+        <CompressCompareModal
+          photos={comparePhotos}
+          index={compareIdx}
+          onIndex={setCompareIdx}
+          onClose={() => setCompareIdx(null)}
+          onToggle={toggleUseOriginal}
+        />
+      )}
 
       <DesktopTheme />
       <style jsx>{`
@@ -452,6 +555,9 @@ export default function AddPhotosPage() {
         }
         .state.compressing { color: var(--accent); }
         .state.errored { color: #f0857b; }
+        .state.ready.is-bigger { color: #f0857b; }
+
+        .picg-thumb.is-clickable { cursor: zoom-in; }
 
         .photo-preview {
           object-fit: contain;

--- a/src/app/desktop/galleries/[id]/new-album/page.tsx
+++ b/src/app/desktop/galleries/[id]/new-album/page.tsx
@@ -17,6 +17,11 @@ import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 import { useCompressIpc } from '@/components/desktop/useCompressIpc';
 import { makePreviewUrl } from '@/components/desktop/makePreview';
 import { fireUndoToast } from '@/components/desktop/UndoToast';
+import {
+  CompressCompareModal,
+  type ComparePhoto,
+  sizeDelta,
+} from '@/components/desktop/CompressCompare';
 
 const README_PATH = 'README.yml';
 
@@ -41,8 +46,11 @@ type PhotoStatus = 'pending' | 'compressing' | 'ready' | 'error';
 type Photo = {
   id: string;
   original: File;
-  preview: string;       // object URL for the original (lightweight, for grid)
+  preview: string;       // 480px downsampled thumbnail — grid only
+  originalUrl: string;   // full-res object URL of the original — compare modal
   compressed?: File;     // squoosh output
+  compressedUrl?: string; // object URL for the compressed encode (compare modal)
+  useOriginal?: boolean;  // true = upload the original (compressed came out larger)
   status: PhotoStatus;
   error?: string;
 };
@@ -88,6 +96,7 @@ export default function NewAlbumPage() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [phase, setPhase] = useState<'form' | 'committing' | 'done'>('form');
+  const [compareIdx, setCompareIdx] = useState<number | null>(null);
 
   // Compression queue: serial, one file at a time, won't restart in-flight items.
   const inFlightRef = useRef<Set<string>>(new Set());
@@ -123,9 +132,22 @@ export default function NewAlbumPage() {
 
     compress(next.original)
       .then((compressed) => {
+        // Re-encoding a lossy source losslessly (or even lossy WebP on an
+        // already-small file) can come out LARGER than the original. Default
+        // the per-photo choice to whichever file is smaller so doing nothing
+        // never inflates a photo; the user can override in the compare modal.
+        const compressedUrl = URL.createObjectURL(compressed);
         setPhotos((prev) =>
           prev.map((p) =>
-            p.id === next.id ? { ...p, compressed, status: 'ready' } : p
+            p.id === next.id
+              ? {
+                  ...p,
+                  compressed,
+                  compressedUrl,
+                  useOriginal: compressed.size >= p.original.size,
+                  status: 'ready',
+                }
+              : p
           )
         );
       })
@@ -146,7 +168,11 @@ export default function NewAlbumPage() {
   // Free object URLs on unmount.
   useEffect(() => {
     return () => {
-      photos.forEach((p) => URL.revokeObjectURL(p.preview));
+      photos.forEach((p) => {
+        URL.revokeObjectURL(p.preview);
+        if (p.originalUrl) URL.revokeObjectURL(p.originalUrl);
+        if (p.compressedUrl) URL.revokeObjectURL(p.compressedUrl);
+      });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -163,6 +189,10 @@ export default function NewAlbumPage() {
       id: crypto.randomUUID(),
       original: file,
       preview: '',
+      // Full-res URL straight off the original File — no decode/copy here,
+      // the browser only decodes it when the compare modal shows this photo.
+      // The grid keeps using the cheap 480px `preview` thumbnail.
+      originalUrl: URL.createObjectURL(file),
       status: 'pending',
     }));
     setPhotos((prev) => [...prev, ...items]);
@@ -179,10 +209,21 @@ export default function NewAlbumPage() {
   function removePhoto(id: string) {
     setPhotos((prev) => {
       const photo = prev.find((p) => p.id === id);
-      if (photo) URL.revokeObjectURL(photo.preview);
+      if (photo) {
+        URL.revokeObjectURL(photo.preview);
+        if (photo.originalUrl) URL.revokeObjectURL(photo.originalUrl);
+        if (photo.compressedUrl) URL.revokeObjectURL(photo.compressedUrl);
+      }
       return prev.filter((p) => p.id !== id);
     });
     setCoverId((cur) => (cur === id ? null : cur));
+  }
+
+  // Flip the per-photo upload choice (compressed vs original).
+  function toggleUseOriginal(id: string) {
+    setPhotos((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, useOriginal: !p.useOriginal } : p))
+    );
   }
 
   function onDrop(e: React.DragEvent) {
@@ -207,6 +248,25 @@ export default function NewAlbumPage() {
     totalOriginal > 0 && totalCompressed > 0
       ? 1 - totalCompressed / totalOriginal
       : 0;
+
+  // Items the compare modal can step through: only photos whose compress
+  // has landed, in grid order. The modal indexes into this list, so the
+  // compare affordance resolves its position by id below.
+  const comparePhotos = useMemo<ComparePhoto[]>(
+    () =>
+      photos
+        .filter((p) => p.status === 'ready' && p.compressed)
+        .map((p) => ({
+          id: p.id,
+          name: p.original.name,
+          beforeUrl: p.originalUrl || p.preview,
+          afterUrl: p.compressedUrl ?? '',
+          originalSize: p.original.size,
+          compressedSize: p.compressed!.size,
+          useOriginal: !!p.useOriginal,
+        })),
+    [photos]
+  );
 
   function validateForm(): string | null {
     if (!form.name.trim()) return 'Album name is required.';
@@ -258,15 +318,25 @@ export default function NewAlbumPage() {
       if (!cover?.compressed) {
         throw new Error('Cover photo is missing compressed bytes.');
       }
-      const coverFilename = cover.compressed.name;
+      // The cover entry must point at the filename we actually write for the
+      // cover photo, which depends on its chosen variant (original keeps the
+      // source extension; compressed is the .webp).
+      const coverFilename = cover.useOriginal
+        ? cover.original.name
+        : cover.compressed.name;
 
-      // Build the BatchFile[] payload: every compressed photo + the new README.
+      // Build the BatchFile[] payload: every chosen photo + the new README.
       const fileEntries: BatchFile[] = [];
       for (const p of photos) {
-        if (!p.compressed) continue;
-        const bytes = new Uint8Array(await p.compressed.arrayBuffer());
+        // Upload the variant the user chose. Default (set at compress time)
+        // is whichever is smaller, so the original wins when the WebP encode
+        // came out larger. Using the original keeps its source extension.
+        const chosen = p.useOriginal ? p.original : p.compressed;
+        if (!chosen) continue;
+        const chosenName = p.useOriginal ? p.original.name : p.compressed!.name;
+        const bytes = new Uint8Array(await chosen.arrayBuffer());
         fileEntries.push({
-          path: `${form.url}/${p.compressed.name}`,
+          path: `${form.url}/${chosenName}`,
           content: bytes,
         });
       }
@@ -459,37 +529,60 @@ export default function NewAlbumPage() {
 
           {photos.length > 0 && (
             <ul className="photos">
-              {photos.map((p) => (
-                <li key={p.id}>
-                  <button
-                    type="button"
-                    className={`picg-thumb ${coverId === p.id ? 'is-cover' : ''}`}
-                    onClick={() => setCoverId(p.id)}
-                    aria-label={`Set ${p.original.name} as cover`}
-                    disabled={submitting}
-                  >
-                    <img src={p.preview} alt="" className="photo-preview" />
-                    {coverId === p.id && <span className="cover-badge">Cover</span>}
-                    {p.status === 'pending' && <span className="state pending">queued</span>}
-                    {p.status === 'compressing' && <span className="state compressing">compressing…</span>}
-                    {p.status === 'error' && <span className="state errored">{p.error ?? 'error'}</span>}
-                    {p.status === 'ready' && p.compressed && (
-                      <span className="state ready">
-                        {formatBytes(p.original.size)} → {formatBytes(p.compressed.size)}
-                      </span>
+              {photos.map((p) => {
+                const ready = p.status === 'ready' && p.compressed;
+                const delta = ready
+                  ? sizeDelta(p.original.size, p.compressed!.size)
+                  : null;
+                const openCompare = () => {
+                  const i = comparePhotos.findIndex((c) => c.id === p.id);
+                  if (i >= 0) setCompareIdx(i);
+                };
+                return (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      className={`picg-thumb ${coverId === p.id ? 'is-cover' : ''}`}
+                      onClick={() => setCoverId(p.id)}
+                      aria-label={`Set ${p.original.name} as cover`}
+                      disabled={submitting}
+                    >
+                      <img src={p.preview} alt="" className="photo-preview" />
+                      {coverId === p.id && <span className="cover-badge">Cover</span>}
+                      {p.status === 'pending' && <span className="state pending">queued</span>}
+                      {p.status === 'compressing' && <span className="state compressing">compressing…</span>}
+                      {p.status === 'error' && <span className="state errored">{p.error ?? 'error'}</span>}
+                      {ready && delta && (
+                        <span className={`state ready ${delta.bigger ? 'is-bigger' : ''}`}>
+                          {formatBytes(p.original.size)} → {formatBytes(p.compressed!.size)}
+                          {' · '}
+                          {delta.label}
+                        </span>
+                      )}
+                    </button>
+                    {ready && (
+                      <button
+                        type="button"
+                        className="compare"
+                        onClick={openCompare}
+                        disabled={submitting}
+                        aria-label={`Compare ${p.original.name}`}
+                      >
+                        ⤢
+                      </button>
                     )}
-                  </button>
-                  <button
-                    type="button"
-                    className="remove"
-                    onClick={() => removePhoto(p.id)}
-                    disabled={submitting}
-                    aria-label="Remove photo"
-                  >
-                    ✕
-                  </button>
-                </li>
-              ))}
+                    <button
+                      type="button"
+                      className="remove"
+                      onClick={() => removePhoto(p.id)}
+                      disabled={submitting}
+                      aria-label="Remove photo"
+                    >
+                      ✕
+                    </button>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </section>
@@ -515,6 +608,16 @@ export default function NewAlbumPage() {
           )}
         </div>
       </main>
+
+      {compareIdx != null && (
+        <CompressCompareModal
+          photos={comparePhotos}
+          index={compareIdx}
+          onIndex={setCompareIdx}
+          onClose={() => setCompareIdx(null)}
+          onToggle={toggleUseOriginal}
+        />
+      )}
 
       <DesktopTheme />
       <style jsx>{`
@@ -604,6 +707,22 @@ export default function NewAlbumPage() {
         .photos li:hover .remove { opacity: 1; }
         .photos .remove:hover { background: rgba(216, 90, 70, 0.7); }
 
+        .photos .compare {
+          position: absolute; top: 6px; right: 36px;
+          width: 24px; height: 24px;
+          border-radius: 50%;
+          background: rgba(20, 18, 14, 0.85);
+          color: var(--text);
+          border: 0;
+          font-size: 12px;
+          line-height: 1;
+          cursor: zoom-in;
+          opacity: 0;
+          transition: opacity 0.15s ease;
+        }
+        .photos li:hover .compare { opacity: 1; }
+        .photos .compare:hover { background: var(--accent); color: var(--accent-text); }
+
         .state {
           position: absolute; left: 6px; bottom: 6px; right: 6px;
           padding: 4px 8px;
@@ -619,6 +738,7 @@ export default function NewAlbumPage() {
         }
         .state.compressing { color: var(--accent); }
         .state.errored { color: #f0857b; }
+        .state.ready.is-bigger { color: #f0857b; }
 
         .cover-badge {
           position: absolute; top: 6px; left: 6px;

--- a/src/app/desktop/settings/page.tsx
+++ b/src/app/desktop/settings/page.tsx
@@ -102,8 +102,10 @@ export default function DesktopSettingsPage() {
                   <div className="row-title">Lossless mode</div>
                   <div className="row-desc">
                     Pixel-perfect WebP output — no quality loss, no resize cap.
-                    Files are 5–10× larger than the default lossy mode but
-                    typically still smaller than the source. JPEG output is
+                    Files are 5–10× larger than the default lossy mode and are
+                    often larger than an already-compressed JPEG/HEIC source.
+                    When adding photos you can compare each result and keep the
+                    original if the lossless encode is bigger. JPEG output is
                     disabled while this is on.
                   </div>
                 </div>

--- a/src/components/desktop/CompressCompare.tsx
+++ b/src/components/desktop/CompressCompare.tsx
@@ -1,0 +1,478 @@
+'use client';
+
+// Before/after comparison lightbox used in the add-photos flow. Lets the
+// user eyeball the original vs the compressed encode and pick, per photo,
+// which one actually gets uploaded.
+//
+// Why this exists: "lossless" WebP (and even lossy WebP on already-small
+// sources) can come out LARGER than the original JPEG/HEIC — re-encoding a
+// lossy source to preserve every pixel is inherently expensive. Rather than
+// silently shipping a bigger file, we surface both and let the user choose.
+// The default choice (decided by the caller) is "whichever is smaller", so
+// doing nothing already never inflates a photo.
+//
+// Generic over a minimal item shape so the same component can serve the
+// add-to-album page, the new-album page, and (later) the web upload pages.
+
+import { useCallback, useEffect } from 'react';
+
+export type ComparePhoto = {
+  id: string;
+  /** Display name of the photo (the original filename is fine). */
+  name: string;
+  /**
+   * Displayable URL for the ORIGINAL. For JPEG/PNG/WebP this can be a full
+   * object URL; for HEIC the browser can't decode it, so the caller may pass
+   * a generated preview (or an empty string, which renders a placeholder).
+   */
+  beforeUrl: string;
+  /** Object URL for the COMPRESSED encode (always a WebP/JPEG we can show). */
+  afterUrl: string;
+  /** Byte size of the original file. */
+  originalSize: number;
+  /** Byte size of the compressed encode. */
+  compressedSize: number;
+  /** Current choice: true = upload the original, false = upload the compressed. */
+  useOriginal: boolean;
+};
+
+export function formatBytes(n?: number): string {
+  if (!n || n === 0) return '—';
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MB`;
+  return `${(n / 1024 ** 3).toFixed(2)} GB`;
+}
+
+/**
+ * Signed size delta of compressed vs original, as a label + sign.
+ * Positive (red) means the compressed encode is LARGER than the source.
+ */
+export function sizeDelta(originalSize: number, compressedSize: number): {
+  pct: number;
+  label: string;
+  bigger: boolean;
+} {
+  if (!originalSize) return { pct: 0, label: '—', bigger: false };
+  const ratio = (compressedSize - originalSize) / originalSize;
+  const pct = Math.round(ratio * 100);
+  const bigger = compressedSize > originalSize;
+  const label = pct === 0 ? '±0%' : pct > 0 ? `+${pct}% larger` : `${pct}% smaller`;
+  return { pct, label, bigger };
+}
+
+export function CompressCompareModal({
+  photos,
+  index,
+  onIndex,
+  onClose,
+  onToggle,
+}: {
+  photos: ComparePhoto[];
+  index: number;
+  onIndex: (i: number) => void;
+  onClose: () => void;
+  onToggle: (id: string) => void;
+}) {
+  const total = photos.length;
+  const photo = photos[index];
+
+  const go = useCallback(
+    (delta: number) => {
+      if (total === 0) return;
+      const next = (index + delta + total) % total;
+      onIndex(next);
+    },
+    [index, total, onIndex],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        go(-1);
+      } else if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        go(1);
+      } else if (e.key === ' ') {
+        e.preventDefault();
+        if (photo) onToggle(photo.id);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [go, onClose, onToggle, photo]);
+
+  if (!photo) return null;
+
+  const delta = sizeDelta(photo.originalSize, photo.compressedSize);
+
+  return (
+    <div className="cc-backdrop" role="dialog" aria-modal="true" onClick={onClose}>
+      <div className="cc-shell" onClick={(e) => e.stopPropagation()}>
+        <header className="cc-head">
+          <div className="cc-title" title={photo.name}>
+            {photo.name}
+          </div>
+          <div className="cc-count">
+            {index + 1} / {total}
+          </div>
+          <button type="button" className="cc-x" aria-label="Close" onClick={onClose}>
+            ×
+          </button>
+        </header>
+
+        <div className="cc-body">
+          {total > 1 && (
+            <button
+              type="button"
+              className="cc-nav cc-prev"
+              aria-label="Previous photo"
+              onClick={() => go(-1)}
+            >
+              ‹
+            </button>
+          )}
+
+          <div className="cc-panes">
+            <figure className={`cc-pane ${photo.useOriginal ? 'is-chosen' : ''}`}>
+              <div className="cc-img-wrap">
+                <ImageOrPlaceholder src={photo.beforeUrl} alt="original" />
+                {photo.useOriginal && <span className="cc-chosen-tag">Using this</span>}
+              </div>
+              <figcaption>
+                <span className="cc-kind">Original</span>
+                <span className="cc-size">{formatBytes(photo.originalSize)}</span>
+              </figcaption>
+            </figure>
+
+            <div className="cc-mid">
+              <span className={`cc-delta ${delta.bigger ? 'is-bigger' : 'is-smaller'}`}>
+                {delta.label}
+              </span>
+            </div>
+
+            <figure className={`cc-pane ${!photo.useOriginal ? 'is-chosen' : ''}`}>
+              <div className="cc-img-wrap">
+                <ImageOrPlaceholder src={photo.afterUrl} alt="compressed" />
+                {!photo.useOriginal && <span className="cc-chosen-tag">Using this</span>}
+              </div>
+              <figcaption>
+                <span className="cc-kind">Compressed</span>
+                <span className="cc-size">{formatBytes(photo.compressedSize)}</span>
+              </figcaption>
+            </figure>
+          </div>
+
+          {total > 1 && (
+            <button
+              type="button"
+              className="cc-nav cc-next"
+              aria-label="Next photo"
+              onClick={() => go(1)}
+            >
+              ›
+            </button>
+          )}
+        </div>
+
+        <footer className="cc-foot">
+          {delta.bigger && (
+            <p className="cc-warn">
+              The compressed encode is larger than the original — keep the
+              original to avoid inflating this photo.
+            </p>
+          )}
+          <div className="cc-toggle" role="group" aria-label="Which file to upload">
+            <button
+              type="button"
+              className={`cc-seg ${!photo.useOriginal ? 'active' : ''}`}
+              onClick={() => {
+                if (photo.useOriginal) onToggle(photo.id);
+              }}
+            >
+              Use compressed
+            </button>
+            <button
+              type="button"
+              className={`cc-seg ${photo.useOriginal ? 'active' : ''}`}
+              onClick={() => {
+                if (!photo.useOriginal) onToggle(photo.id);
+              }}
+            >
+              Use original
+            </button>
+          </div>
+        </footer>
+      </div>
+
+      <style jsx>{`
+        .cc-backdrop {
+          position: fixed;
+          inset: 0;
+          z-index: 1000;
+          background: rgba(0, 0, 0, 0.78);
+          backdrop-filter: blur(3px);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 32px;
+        }
+        .cc-shell {
+          display: flex;
+          flex-direction: column;
+          width: min(1100px, 100%);
+          max-height: 100%;
+          background: var(--bg-card, #1b1b1b);
+          border: 1px solid var(--border, #333);
+          border-radius: 14px;
+          overflow: hidden;
+        }
+        .cc-head {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          padding: 14px 18px;
+          border-bottom: 1px solid var(--border, #333);
+        }
+        .cc-title {
+          flex: 1;
+          min-width: 0;
+          font-family: var(--mono, monospace);
+          font-size: 13px;
+          color: var(--text, #eee);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .cc-count {
+          font-family: var(--mono, monospace);
+          font-size: 12px;
+          color: var(--text-muted, #999);
+          letter-spacing: 0.04em;
+        }
+        .cc-x {
+          border: none;
+          background: transparent;
+          color: var(--text-muted, #999);
+          font-size: 22px;
+          line-height: 1;
+          cursor: pointer;
+          padding: 0 4px;
+        }
+        .cc-x:hover {
+          color: var(--text, #eee);
+        }
+
+        .cc-body {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 18px;
+          min-height: 0;
+          flex: 1;
+        }
+        .cc-panes {
+          flex: 1;
+          display: grid;
+          grid-template-columns: 1fr auto 1fr;
+          gap: 14px;
+          align-items: center;
+          min-width: 0;
+        }
+        .cc-pane {
+          margin: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          min-width: 0;
+          padding: 8px;
+          border: 1px solid transparent;
+          border-radius: 10px;
+          transition: border-color 0.15s ease, background 0.15s ease;
+        }
+        .cc-pane.is-chosen {
+          border-color: var(--accent, #d8a657);
+          background: rgba(255, 255, 255, 0.03);
+        }
+        .cc-img-wrap {
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          background: rgba(0, 0, 0, 0.35);
+          border-radius: 8px;
+          overflow: hidden;
+          aspect-ratio: 4 / 3;
+        }
+        .cc-img-wrap :global(img) {
+          max-width: 100%;
+          max-height: 52vh;
+          object-fit: contain;
+          display: block;
+        }
+        .cc-chosen-tag {
+          position: absolute;
+          top: 8px;
+          left: 8px;
+          font-family: var(--mono, monospace);
+          font-size: 10px;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          padding: 3px 7px;
+          border-radius: 5px;
+          background: var(--accent, #d8a657);
+          color: #1a1a1a;
+        }
+        figcaption {
+          display: flex;
+          align-items: baseline;
+          justify-content: space-between;
+          gap: 10px;
+          font-family: var(--mono, monospace);
+        }
+        .cc-kind {
+          font-size: 11px;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
+          color: var(--text-muted, #999);
+        }
+        .cc-size {
+          font-size: 13px;
+          color: var(--text, #eee);
+        }
+        .cc-mid {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0 2px;
+        }
+        .cc-delta {
+          font-family: var(--mono, monospace);
+          font-size: 11px;
+          letter-spacing: 0.03em;
+          text-align: center;
+          padding: 4px 8px;
+          border-radius: 6px;
+          white-space: nowrap;
+        }
+        .cc-delta.is-smaller {
+          color: #7bb37b;
+          background: rgba(123, 179, 123, 0.12);
+        }
+        .cc-delta.is-bigger {
+          color: #e0897e;
+          background: rgba(216, 90, 70, 0.14);
+        }
+
+        .cc-nav {
+          flex-shrink: 0;
+          border: 1px solid var(--border, #333);
+          background: transparent;
+          color: var(--text, #eee);
+          width: 36px;
+          height: 56px;
+          border-radius: 8px;
+          font-size: 24px;
+          line-height: 1;
+          cursor: pointer;
+        }
+        .cc-nav:hover {
+          border-color: var(--accent, #d8a657);
+          color: var(--accent, #d8a657);
+        }
+
+        .cc-foot {
+          padding: 14px 18px 18px;
+          border-top: 1px solid var(--border, #333);
+          display: flex;
+          flex-direction: column;
+          gap: 10px;
+          align-items: center;
+        }
+        .cc-warn {
+          margin: 0;
+          font-size: 12px;
+          color: #e0897e;
+          text-align: center;
+        }
+        .cc-toggle {
+          display: inline-flex;
+          border: 1px solid var(--border, #333);
+          border-radius: 8px;
+          overflow: hidden;
+        }
+        .cc-seg {
+          border: none;
+          background: transparent;
+          color: var(--text-muted, #999);
+          font-family: var(--mono, monospace);
+          font-size: 12px;
+          letter-spacing: 0.03em;
+          padding: 9px 18px;
+          cursor: pointer;
+        }
+        .cc-seg + .cc-seg {
+          border-left: 1px solid var(--border, #333);
+        }
+        .cc-seg.active {
+          background: var(--accent, #d8a657);
+          color: #1a1a1a;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// Small <img> wrapper that swaps in a placeholder when the source can't be
+// decoded (the common case: a HEIC original the browser won't render).
+function ImageOrPlaceholder({ src, alt }: { src: string; alt: string }) {
+  if (!src) return <PreviewUnavailable />;
+  return (
+    <>
+      <img
+        src={src}
+        alt={alt}
+        onError={(e) => {
+          const el = e.currentTarget;
+          el.style.display = 'none';
+          const sib = el.nextElementSibling as HTMLElement | null;
+          if (sib) sib.style.display = 'flex';
+        }}
+      />
+      {/* Revealed by the <img> onError above when the source can't be
+          decoded — chiefly a HEIC original the browser won't render. */}
+      <div style={{ display: 'none', width: '100%', height: '100%' }}>
+        <PreviewUnavailable />
+      </div>
+    </>
+  );
+}
+
+function PreviewUnavailable() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        fontFamily: 'var(--mono, monospace)',
+        fontSize: 11,
+        letterSpacing: '0.05em',
+        textTransform: 'uppercase',
+        color: 'var(--text-faint, #777)',
+        textAlign: 'center',
+        padding: 16,
+      }}
+    >
+      preview unavailable
+    </div>
+  );
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -4,9 +4,13 @@ export interface CompressionSettings {
   outputFormat: 'webp' | 'jpeg';
   // When true, encode WebP in lossless mode (every pixel preserved,
   // no resize cap applied). Output is ~3–10× larger than lossy WebP
-  // but still smaller than the original HEIC/JPEG and pixel-perfect
-  // for archival use. Only meaningful when enableWebP=true and
-  // outputFormat='webp' — JPEG has no lossless mode.
+  // and is frequently LARGER than an already-compressed JPEG/HEIC
+  // source — re-encoding a lossy original to preserve every pixel
+  // (artefacts and all) is inherently expensive, so "lossless" does
+  // not mean "smaller". Pixel-perfect, for archival use. The add-photos
+  // step shows the per-photo size delta and lets you keep the original
+  // when the lossless encode comes out bigger. Only meaningful when
+  // enableWebP=true and outputFormat='webp' — JPEG has no lossless mode.
   lossless: boolean;
   // Encoder quality (0–100). Applied to both WebP-lossy and JPEG.
   // Ignored when lossless=true. Sharp + squoosh both default to ~75


### PR DESCRIPTION
## What & why

A user hit "lossless mode keeps making files *bigger*". That's expected for the codec — losslessly re-encoding an already-lossy JPEG/HEIC to WebP preserves every pixel (artefacts included) and is frequently larger than the source. But the old add-photos flow **always uploaded the compressed output**, so it silently inflated photos. This PR puts the choice in the user's hands and fixes the surrounding rough edges.

## Changes

### 1. Compare original vs compressed, choose per photo (`feat`)
- New `CompressCompare` lightbox component (shared by the add-to-album and new-album pages): full-screen before/after, size delta, and a per-photo **use compressed / use original** toggle. Keyboard: ←/→ navigate, Space toggle, Esc close.
- Each ready thumbnail is clickable to open it; the size badge turns red when the encode came out larger than the source.
- **Default choice = whichever file is smaller** (`useOriginal = compressedSize >= originalSize`), so doing nothing never inflates a photo; the user can override after eyeballing quality.
- Upload writes the chosen variant — original keeps its source extension, compressed is the `.webp`. new-album derives the cover filename from the chosen variant so README `cover:` refs stay correct.
- The compare modal shows the **full-resolution** original (object URL off the source `File`), not the 480px grid thumbnail — fixes the original looking blurrier than the full-res compressed side.
- All object URLs (`preview` / `originalUrl` / `compressedUrl`) revoked on remove + unmount.

### 2. Fix misleading settings copy (`docs`)
The lossless setting claimed output is "still smaller than the source" — wrong for already-compressed sources. Reworded the interface comment and the settings-page description, pointing at the new compare step.

### 3. Fix app icon never being generated (`build`)
`build/icon.icns` is gitignored (a generated artifact) and `scripts/build-icon.js` was never invoked by any packaging script, so clean builds fell back to the default Electron icon. Added a `build:icon` step at the front of `dist:mac` and `pack:dir` so the icns is always rendered from `build/icon.svg` first.

## Testing
- `tsc --noEmit` clean; `next lint` clean.
- Full `dist:mac` build succeeds; arm64 `.app` verified to carry the correct icon and the full-res compare behavior.

## Reviewer notes
- HEIC originals can't be decoded by the browser, so the compare modal's "original" side shows a "preview unavailable" placeholder for them (expected — HEIC can't render in a web context). The compressed WebP side still shows.
- Web upload pages under `src/app/gallery/...` were intentionally left unchanged (out of scope for this desktop-focused fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
