### PR TITLE
fix(desktop): return Settings back link to the previous screen

### DIFF
--- a/src/app/desktop/settings/page.tsx
+++ b/src/app/desktop/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import {
   getCompressionSettings,
@@ -11,6 +11,7 @@ import {
 import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 
 export default function DesktopSettingsPage() {
+  const router = useRouter();
   const [settings, setSettings] = useState<CompressionSettings>(() =>
     getCompressionSettings()
   );
@@ -18,6 +19,17 @@ export default function DesktopSettingsPage() {
   useEffect(() => {
     setSettings(getCompressionSettings());
   }, []);
+
+  // Settings is reachable from the account menu on every desktop screen, so
+  // "back" should return wherever the user came from — not a fixed page.
+  // Fall back to the galleries list if there's no in-app history to pop.
+  function handleBack() {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/desktop/galleries');
+    }
+  }
 
   function update(patch: Partial<CompressionSettings>) {
     const next = { ...settings, ...patch };
@@ -30,9 +42,9 @@ export default function DesktopSettingsPage() {
       <Topbar />
 
       <main>
-        <Link href="/desktop/galleries" className="picg-back-link">
-          ← All galleries
-        </Link>
+        <button type="button" onClick={handleBack} className="picg-back-link back-btn">
+          ← Back
+        </button>
 
         <section className="hero">
           <h1>Settings</h1>
@@ -189,6 +201,9 @@ export default function DesktopSettingsPage() {
       <DesktopTheme />
       <style jsx>{`
         main { padding: 24px 40px 64px; max-width: 760px; margin: 0 auto; }
+
+        /* Reset native button chrome so it reads as the shared back link. */
+        .back-btn { background: none; border: 0; padding: 0; cursor: pointer; }
 
         .hero { margin-bottom: 32px; }
         .hero h1 {


### PR DESCRIPTION
## What

The desktop **Settings** page's back link now returns to the screen the user came from, instead of always jumping to the galleries overview.

## Why

Settings is opened from the account menu in the top bar (`DesktopChrome`), which is rendered on **every** desktop screen. But the settings page's back link was hardcoded:

```tsx
<Link href="/desktop/galleries">← All galleries</Link>
```

So no matter where you opened Settings from (a gallery, an album, stats…), "back" always landed on the galleries overview (总界面) rather than the previous screen (上一个界面). Reported by a user.

## How

`src/app/desktop/settings/page.tsx`:

- Replace the hardcoded `<Link>` with a button that calls `router.back()` to pop browser/Electron history.
- Fall back to `router.push('/desktop/galleries')` when there's no in-app history to pop (e.g. a cold direct load) — guarded by `window.history.length > 1`.
- Relabel `← All galleries` → `← Back`, since the destination is now dynamic.
- Add a small `.back-btn` style to reset native button chrome so it visually matches the shared `.picg-back-link`.

## Notes for reviewers

- The `<button>` is a real DOM element, so styled-jsx's scoped `.back-btn` class applies correctly (unlike the `<Link>` footgun the `check:links` guard protects against); the visual `.picg-back-link` class is global.
- Verified with `tsc --noEmit` (passes) and `npm run check:links` (passes). Not manually exercised in a running Electron build.
- The web settings page (`src/app/settings/page.tsx`) is separate and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)