### PR TITLE
feat(album): justified (Apple Photos) grid layout for album pages

### DIFF
--- a/src/app/desktop/galleries/[id]/[album]/page.tsx
+++ b/src/app/desktop/galleries/[id]/[album]/page.tsx
@@ -17,8 +17,13 @@ import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 import { useAdapterImage } from '@/components/desktop/useAdapterImage';
 import { fireUndoToast, UndoToastHost } from '@/components/desktop/UndoToast';
 import { PushButton } from '@/components/desktop/PushButton';
+import { computeJustifiedRows, useElementWidth, DEFAULT_RATIO } from '@/lib/justifiedLayout';
 
 const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.avif', '.bmp'];
+
+// Justified ("Apple Photos") grid tuning for the desktop album page.
+const THUMB_ROW_HEIGHT = 200;
+const THUMB_GAP = 8;
 
 type AlbumMeta = {
   name: string;
@@ -130,6 +135,10 @@ export default function AlbumPage() {
   const [images, setImages] = useState<DirectoryEntry[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [lightboxPath, setLightboxPath] = useState<string | null>(null);
+  // Aspect ratio (natural w/h) per image, measured from each thumb's <img onLoad>;
+  // feeds the justified ("Apple Photos") grid. Unmeasured images use DEFAULT_RATIO.
+  const [imageRatios, setImageRatios] = useState<Record<string, number>>({});
+  const { ref: galleryRef, width: galleryWidth } = useElementWidth<HTMLDivElement>();
 
   const [editOpen, setEditOpen] = useState(false);
   const [editPhase, setEditPhase] = useState<'form' | 'pickCover'>('form');
@@ -149,6 +158,21 @@ export default function AlbumPage() {
   const [pushing, setPushing] = useState(false);
   const [ahead, setAhead] = useState(0);
   const [opError, setOpError] = useState<string | null>(null);
+
+  const recordRatio = (name: string, ratio: number) => {
+    setImageRatios((prev) => (prev[name] === ratio ? prev : { ...prev, [name]: ratio }));
+  };
+
+  // Partition the album's images into justified rows that fill the grid width.
+  const thumbRows = useMemo(
+    () =>
+      computeJustifiedRows(
+        (images ?? []).map((img) => ({ item: img, ratio: imageRatios[img.name] ?? DEFAULT_RATIO })),
+        galleryWidth,
+        { targetRowHeight: THUMB_ROW_HEIGHT, gap: THUMB_GAP }
+      ),
+    [images, imageRatios, galleryWidth]
+  );
 
   useEffect(() => {
     setBridge(getPicgBridge());
@@ -672,23 +696,30 @@ export default function AlbumPage() {
                 </button>
               </div>
             )}
-            <ul className="picg-thumbs">
-              {images.map((img) => (
-                <Thumb
-                  key={img.path}
-                  adapter={adapter}
-                  albumUrl={albumUrl}
-                  name={img.name}
-                  galleryId={gallery.id}
-                  selectMode={selectMode}
-                  selected={selected.has(img.name)}
-                  onOpen={() => {
-                    if (selectMode) toggleSelected(img.name);
-                    else setLightboxPath(`${albumUrl}/${img.name}`);
-                  }}
-                />
+            <div className="picg-thumbs-justified" ref={galleryRef}>
+              {thumbRows.map((row, rowIndex) => (
+                <div className="picg-thumb-row" key={rowIndex} style={{ height: row.height }}>
+                  {row.tiles.map(({ item: img, width, height }) => (
+                    <Thumb
+                      key={img.path}
+                      adapter={adapter}
+                      albumUrl={albumUrl}
+                      name={img.name}
+                      galleryId={gallery.id}
+                      width={width}
+                      height={height}
+                      selectMode={selectMode}
+                      selected={selected.has(img.name)}
+                      onRatio={recordRatio}
+                      onOpen={() => {
+                        if (selectMode) toggleSelected(img.name);
+                        else setLightboxPath(`${albumUrl}/${img.name}`);
+                      }}
+                    />
+                  ))}
+                </div>
               ))}
-            </ul>
+            </div>
           </>
         )}
       </main>
@@ -975,16 +1006,22 @@ function Thumb({
   albumUrl,
   name,
   galleryId,
+  width,
+  height,
   selectMode,
   selected,
+  onRatio,
   onOpen,
 }: {
   adapter: StorageAdapter | null;
   albumUrl: string;
   name: string;
   galleryId: string;
+  width: number;
+  height: number;
   selectMode: boolean;
   selected: boolean;
+  onRatio: (name: string, ratio: number) => void;
   onOpen: () => void;
 }) {
   const { src } = useAdapterImage(adapter, `${albumUrl}/${name}`, {
@@ -992,17 +1029,28 @@ function Thumb({
     thumbWidth: 480,
   });
   return (
-    <li>
-      <button
-        className={`picg-thumb ${selectMode && selected ? 'is-selected' : ''}`}
-        onClick={onOpen}
-        aria-label={name}
-        aria-pressed={selectMode ? selected : undefined}
-      >
-        {src ? <img src={src} alt={name} loading="lazy" /> : <div className="picg-thumb-placeholder" />}
-        {selectMode && selected && <span className="picg-thumb-check">✓</span>}
-      </button>
-    </li>
+    <button
+      className={`picg-thumb ${selectMode && selected ? 'is-selected' : ''}`}
+      style={{ width, height }}
+      onClick={onOpen}
+      aria-label={name}
+      aria-pressed={selectMode ? selected : undefined}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt={name}
+          loading="lazy"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget;
+            if (naturalWidth && naturalHeight) onRatio(name, naturalWidth / naturalHeight);
+          }}
+        />
+      ) : (
+        <div className="picg-thumb-placeholder" />
+      )}
+      {selectMode && selected && <span className="picg-thumb-check">✓</span>}
+    </button>
   );
 }
 

--- a/src/app/gallery/[owner]/[repo]/[album]/page.tsx
+++ b/src/app/gallery/[owner]/[repo]/[album]/page.tsx
@@ -1,9 +1,14 @@
 'use client';
 import { useParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import yaml from 'js-yaml';
 import { fetchGitHubFile, updateGitHubFile, getFileSha, getGitHubToken, decodeGitHubPath, encodeGitHubPath, deleteDirectory, deleteFiles } from '@/lib/github';
+import { computeJustifiedRows, useElementWidth, DEFAULT_RATIO } from '@/lib/justifiedLayout';
+
+// Justified ("Apple Photos") grid tuning for the album page.
+const ROW_TARGET_HEIGHT = 240;
+const ROW_GAP = 12;
 
 type Config = {
   thumbnail_url: string;
@@ -40,6 +45,10 @@ export default function AlbumPage() {
   const [config, setConfig] = useState<Config | null>(null);
   const [albumInfo, setAlbumInfo] = useState<AlbumInfo | null>(null);
   const [images, setImages] = useState<ImageFile[]>([]);
+  // Aspect ratio (natural w/h) per image, measured from <img onLoad>. Drives the
+  // justified layout; unmeasured images fall back to DEFAULT_RATIO.
+  const [imageRatios, setImageRatios] = useState<Record<string, number>>({});
+  const { ref: galleryRef, width: galleryWidth } = useElementWidth<HTMLDivElement>();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isDeleteMode, setIsDeleteMode] = useState(false);
@@ -481,6 +490,24 @@ export default function AlbumPage() {
       .replace(/<p>(<pre>.*<\/pre>)<\/p>/gim, '$1');
   };
 
+  const recordRatio = (name: string, img: HTMLImageElement) => {
+    const { naturalWidth, naturalHeight } = img;
+    if (!naturalWidth || !naturalHeight) return;
+    const ratio = naturalWidth / naturalHeight;
+    setImageRatios((prev) => (prev[name] === ratio ? prev : { ...prev, [name]: ratio }));
+  };
+
+  // Partition images into justified rows that fill the gallery width.
+  const galleryRows = useMemo(
+    () =>
+      computeJustifiedRows(
+        images.map((image) => ({ item: image, ratio: imageRatios[image.name] ?? DEFAULT_RATIO })),
+        galleryWidth,
+        { targetRowHeight: ROW_TARGET_HEIGHT, gap: ROW_GAP }
+      ),
+    [images, imageRatios, galleryWidth]
+  );
+
   if (loading) {
     return (
       <div className="container">
@@ -632,63 +659,73 @@ export default function AlbumPage() {
         </div>
       </aside>
 
-      {/* 右侧图片网格 */}
+      {/* 右侧图片网格 —— justified（按原始宽高比的等高行）布局 */}
       <main className="album-content">
-        <div className="images-grid">
-          {images.map((image) => (
-            <div 
-              key={image.name} 
-              className={`image-card ${isDeleteMode ? 'delete-mode' : ''} ${selectedImages.has(image.name) ? 'selected' : ''}`}
-            >
-              {isDeleteMode && (
-                <div 
-                  className={`select-overlay ${selectedImages.has(image.name) ? 'selected' : ''}`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    toggleImageSelection(image.name);
-                  }}
-                >
-                  {selectedImages.has(image.name) && (
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                      <path 
-                        d="M20 6L9 17L4 12" 
-                        stroke="white" 
-                        strokeWidth="3" 
-                        strokeLinecap="round" 
-                        strokeLinejoin="round"
+        <div className="justified-gallery" ref={galleryRef}>
+          {galleryRows.map((row, rowIndex) => (
+            <div className="jg-row" key={rowIndex} style={{ height: row.height }}>
+              {row.tiles.map(({ item: image, width, height }) => {
+                const isSelected = selectedImages.has(image.name);
+                return (
+                  <div
+                    key={image.name}
+                    className={`image-card ${isDeleteMode ? 'delete-mode' : ''} ${isSelected ? 'selected' : ''}`}
+                    style={{ width, height }}
+                  >
+                    {isDeleteMode && (
+                      <div
+                        className={`select-overlay ${isSelected ? 'selected' : ''}`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleImageSelection(image.name);
+                        }}
+                      >
+                        {isSelected && (
+                          <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                            <path
+                              d="M20 6L9 17L4 12"
+                              stroke="white"
+                              strokeWidth="3"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                          </svg>
+                        )}
+                      </div>
+                    )}
+                    <div
+                      className="image-wrapper"
+                      onClick={() => {
+                        if (isDeleteMode) {
+                          toggleImageSelection(image.name);
+                        } else {
+                          // 点击图片查看大图
+                          window.open(getImageUrl(image.name, false), '_blank');
+                        }
+                      }}
+                    >
+                      <img
+                        src={getImageUrl(image.name, true)}
+                        alt={image.name}
+                        crossOrigin="anonymous"
+                        loading="lazy"
+                        onLoad={(e) => recordRatio(image.name, e.currentTarget)}
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          // 如果缩略图失败，尝试原图
+                          if (target.src.includes('thumbnail')) {
+                            target.src = getImageUrl(image.name, false);
+                          }
+                        }}
                       />
-                    </svg>
-                  )}
-                </div>
-              )}
-              <div 
-                className="image-wrapper"
-                onClick={() => {
-                  if (isDeleteMode) {
-                    toggleImageSelection(image.name);
-                  } else {
-                    // 点击图片查看大图
-                    window.open(getImageUrl(image.name, false), '_blank');
-                  }
-                }}
-              >
-                <img
-                  src={getImageUrl(image.name, true)}
-                  alt={image.name}
-                  crossOrigin="anonymous"
-                  onError={(e) => {
-                    const target = e.target as HTMLImageElement;
-                    // 如果缩略图失败，尝试原图
-                    if (target.src.includes('thumbnail')) {
-                      target.src = getImageUrl(image.name, false);
-                    }
-                  }}
-                />
-              </div>
-              <div className="image-info">
-                <div className="image-name">{image.name}</div>
-                <div className="image-size">{(image.size / 1024).toFixed(1)} KB</div>
-              </div>
+                    </div>
+                    <div className="image-info">
+                      <div className="image-name">{image.name}</div>
+                      <div className="image-size">{(image.size / 1024).toFixed(1)} KB</div>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
           ))}
         </div>
@@ -1095,59 +1132,89 @@ export default function AlbumPage() {
           overflow-y: auto;
         }
         
-        .images-grid {
-          display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-          gap: 16px;
+        .justified-gallery {
+          display: flex;
+          flex-direction: column;
+          gap: ${ROW_GAP}px;
         }
-        
+
+        .jg-row {
+          display: flex;
+          flex-direction: row;
+          gap: ${ROW_GAP}px;
+          justify-content: flex-start;
+        }
+
         .image-card {
-          background: var(--surface);
-          border-radius: 12px;
+          position: relative;
+          flex: 0 0 auto;
+          border-radius: 10px;
           overflow: hidden;
           border: 1px solid var(--border);
-          transition: all 0.3s ease;
-          position: relative;
+          background: var(--border);
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
-        
+
         .image-card:hover {
           transform: translateY(-2px);
-          box-shadow: 0 8px 25px color-mix(in srgb, var(--text), transparent 85%);
+          box-shadow: 0 8px 25px color-mix(in srgb, var(--text), transparent 80%);
+          z-index: 1;
         }
-        
+
         .image-wrapper {
-          aspect-ratio: 1;
+          width: 100%;
+          height: 100%;
           overflow: hidden;
-          background: var(--border);
           cursor: pointer;
         }
-        
+
         .image-wrapper img {
           width: 100%;
           height: 100%;
           object-fit: cover;
+          display: block;
           transition: transform 0.3s ease;
         }
-        
-        .image-wrapper:hover img {
-          transform: scale(1.05);
+
+        .image-card:hover .image-wrapper img {
+          transform: scale(1.04);
         }
-        
+
+        /* Caption as a bottom hover overlay so it never breaks the row height. */
         .image-info {
-          padding: 12px;
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          padding: 18px 10px 8px;
+          background: linear-gradient(to top, rgba(0, 0, 0, 0.62), transparent);
+          opacity: 0;
+          transition: opacity 0.2s ease;
+          pointer-events: none;
         }
-        
+
+        .image-card:hover .image-info {
+          opacity: 1;
+        }
+
         .image-name {
-          font-size: 13px;
+          font-size: 12px;
           font-weight: 500;
-          color: var(--text);
-          margin-bottom: 4px;
+          color: #fff;
+          margin-bottom: 2px;
           word-break: break-all;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+          text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
         }
-        
+
         .image-size {
-          font-size: 11px;
-          color: var(--text-secondary);
+          font-size: 10px;
+          color: rgba(255, 255, 255, 0.85);
+          text-shadow: 0 1px 2px rgba(0, 0, 0, 0.55);
         }
         
         .loading, .error {
@@ -1350,7 +1417,7 @@ export default function AlbumPage() {
           bottom: 0;
           background: color-mix(in srgb, var(--danger), transparent 90%);
           pointer-events: none;
-          border-radius: 12px;
+          border-radius: 10px;
         }
         
         .select-overlay {

--- a/src/components/DesktopChrome.tsx
+++ b/src/components/DesktopChrome.tsx
@@ -709,11 +709,24 @@ export function DesktopTheme() {
       }
       .picg-album-meta-dot { color: var(--text-faint); }
 
-      /* Thumbnail grid (album page) */
+      /* Thumbnail grid (cover picker) */
       .picg-thumbs {
         list-style: none; margin: 0; padding: 0;
         display: grid; gap: 8px;
         grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      }
+      /* Justified album grid (Apple Photos style): rows of native-ratio photos */
+      .picg-thumbs-justified {
+        list-style: none; margin: 0; padding: 0;
+        display: flex; flex-direction: column; gap: 8px;
+      }
+      .picg-thumb-row {
+        display: flex; flex-direction: row; gap: 8px;
+        justify-content: flex-start;
+      }
+      .picg-thumbs-justified .picg-thumb {
+        aspect-ratio: auto;
+        flex: 0 0 auto;
       }
       .picg-thumb {
         position: relative;

--- a/src/lib/justifiedLayout.test.ts
+++ b/src/lib/justifiedLayout.test.ts
@@ -1,0 +1,69 @@
+import { computeJustifiedRows, DEFAULT_RATIO } from './justifiedLayout';
+
+const opts = { targetRowHeight: 200, gap: 8 };
+
+function makeItems(ratios: number[]) {
+  return ratios.map((ratio, i) => ({ item: i, ratio }));
+}
+
+describe('computeJustifiedRows', () => {
+  it('returns nothing when width is unknown or there are no items', () => {
+    expect(computeJustifiedRows(makeItems([1.5]), 0, opts)).toEqual([]);
+    expect(computeJustifiedRows([], 1000, opts)).toEqual([]);
+  });
+
+  it('fills each non-last row to exactly the container width (minus gaps)', () => {
+    // Three 1.5 photos: at the 200px target each is 300px wide → 900 + 16 gaps
+    // = 916 > 800, so the first two close a row and scale to fill 800.
+    const rows = computeJustifiedRows(makeItems([1.5, 1.5, 1.5]), 800, opts);
+    const filled = rows.filter((r) => !r.isLast);
+    expect(filled.length).toBeGreaterThan(0);
+    for (const row of filled) {
+      const total =
+        row.tiles.reduce((sum, t) => sum + t.width, 0) +
+        opts.gap * (row.tiles.length - 1);
+      expect(total).toBeCloseTo(800, 4);
+    }
+  });
+
+  it('keeps a row at one height and sizes each tile to its own ratio (no crop)', () => {
+    const ratios = [2, 0.7, 1.2, 1.8, 1];
+    const rows = computeJustifiedRows(makeItems(ratios), 900, opts);
+    for (const row of rows) {
+      for (const tile of row.tiles) {
+        expect(tile.height).toBeCloseTo(row.height, 6);
+        // width follows the photo's own ratio → the box matches the image
+        expect(tile.width).toBeCloseTo(ratios[tile.item] * tile.height, 6);
+      }
+    }
+  });
+
+  it('left-aligns the last row at the target height instead of stretching', () => {
+    const rows = computeJustifiedRows(makeItems([1.5, 1.5, 1.5, 1.5]), 800, opts);
+    const last = rows[rows.length - 1];
+    expect(last.isLast).toBe(true);
+    expect(last.height).toBeCloseTo(opts.targetRowHeight, 6);
+  });
+
+  it('caps row height so a lone portrait does not balloon', () => {
+    const rows = computeJustifiedRows(makeItems([0.6]), 2000, {
+      ...opts,
+      maxRowHeight: 320,
+    });
+    expect(rows[0].height).toBeLessThanOrEqual(320);
+  });
+
+  it('substitutes the default ratio for invalid measurements', () => {
+    const rows = computeJustifiedRows(
+      [
+        { item: 'a', ratio: 0 },
+        { item: 'b', ratio: NaN },
+      ],
+      5000,
+      opts
+    );
+    for (const tile of rows.flatMap((r) => r.tiles)) {
+      expect(tile.width / tile.height).toBeCloseTo(DEFAULT_RATIO, 6);
+    }
+  });
+});

--- a/src/lib/justifiedLayout.ts
+++ b/src/lib/justifiedLayout.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+// A justified ("Apple Photos / Flickr") gallery layout. Each photo keeps its
+// native aspect ratio; a row is scaled so its photos share one height and the
+// row exactly fills the container width. Wide panoramas span most of a row,
+// portraits stay narrow — nothing is cropped.
+//
+// The geometry is a pure function so it can be unit-tested without a DOM. The
+// caller measures each image's aspect ratio (natural width / height) however
+// it likes — for us that's `<img onLoad>` reading naturalWidth/naturalHeight —
+// and feeds the ratios in. Unmeasured images can use DEFAULT_RATIO so the
+// layout renders immediately and refines as photos load.
+
+/** Fallback aspect ratio (3:2 landscape) for images not yet measured. */
+export const DEFAULT_RATIO = 3 / 2;
+
+export type RatioItem<T> = {
+  item: T;
+  /** aspect ratio = natural width / natural height (> 0) */
+  ratio: number;
+};
+
+export type Tile<T> = {
+  item: T;
+  width: number;
+  height: number;
+};
+
+export type Row<T> = {
+  tiles: Tile<T>[];
+  height: number;
+  /** true for the trailing row, which is left-aligned at the target height */
+  isLast: boolean;
+};
+
+export type JustifiedOptions = {
+  /** The height rows aim for before being scaled to fill the width. */
+  targetRowHeight: number;
+  /** Gap between tiles (and the basis for between-row spacing). */
+  gap: number;
+  /**
+   * Upper bound on a scaled row's height so a near-empty row (e.g. one
+   * portrait) doesn't balloon. Defaults to 1.6× the target.
+   */
+  maxRowHeight?: number;
+};
+
+/**
+ * Partition `items` into justified rows that each fill `containerWidth`.
+ * Returns an empty array when the width is unknown (0) or there are no items.
+ */
+export function computeJustifiedRows<T>(
+  items: RatioItem<T>[],
+  containerWidth: number,
+  { targetRowHeight, gap, maxRowHeight }: JustifiedOptions
+): Row<T>[] {
+  if (containerWidth <= 0 || items.length === 0) return [];
+
+  const cap = maxRowHeight ?? targetRowHeight * 1.6;
+  const rows: Row<T>[] = [];
+  let row: RatioItem<T>[] = [];
+  let ratioSum = 0;
+
+  const flush = (isLast: boolean) => {
+    if (row.length === 0) return;
+    const gaps = gap * (row.length - 1);
+    const available = Math.max(1, containerWidth - gaps);
+    // Last row keeps the target height (left-aligned) rather than stretching a
+    // handful of photos across the whole width.
+    const rawHeight = isLast ? targetRowHeight : available / ratioSum;
+    const height = Math.min(rawHeight, cap);
+    const tiles: Tile<T>[] = row.map(({ item, ratio }) => ({
+      item,
+      width: ratio * height,
+      height,
+    }));
+    rows.push({ tiles, height, isLast });
+    row = [];
+    ratioSum = 0;
+  };
+
+  for (const it of items) {
+    // Guard against bad ratios so one zero/NaN can't break the whole layout.
+    const ratio = it.ratio > 0 && Number.isFinite(it.ratio) ? it.ratio : DEFAULT_RATIO;
+    row.push({ item: it.item, ratio });
+    ratioSum += ratio;
+    const gaps = gap * (row.length - 1);
+    const projectedWidth = ratioSum * targetRowHeight + gaps;
+    if (projectedWidth >= containerWidth) flush(false);
+  }
+  flush(true);
+  return rows;
+}
+
+/**
+ * Track an element's content-box width via ResizeObserver. Returns a callback
+ * ref to attach and the latest width (0 until measured / on the server).
+ */
+export function useElementWidth<E extends HTMLElement = HTMLDivElement>(): {
+  ref: (el: E | null) => void;
+  width: number;
+} {
+  const [width, setWidth] = useState(0);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const ref = useCallback((el: E | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    setWidth(el.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setWidth(entry.contentRect.width);
+    });
+    observer.observe(el);
+    observerRef.current = observer;
+  }, []);
+
+  return { ref, width };
+}


### PR DESCRIPTION
## What

Both album pages (web management + desktop management) now render photos in a **justified / "Apple Photos All Photos"** layout instead of a fixed square-crop grid. Each photo keeps its native aspect ratio; every row is scaled so its photos share one height and the row fills the container width. Panoramas span wide, portraits stay narrow, **nothing is cropped**.

Before: `grid-template-columns: repeat(auto-fill, minmax(…))` + `aspect-ratio: 1` + `object-fit: cover` (every photo cropped to a square).
After: native-ratio tiles packed into variable-height rows.

## Why

Requested — match the justified look of Apple Photos so wide/tall shots aren't center-cropped in the album view.

## How

- **New `src/lib/justifiedLayout.ts`** (shared, dependency-free):
  - `computeJustifiedRows()` — pure row-packing geometry (last row left-aligned at target height; per-row height cap; bad-ratio fallback). Covered by `justifiedLayout.test.ts` (6 cases).
  - `useElementWidth()` — `ResizeObserver` hook so rows re-pack on resize.
- **Web album page** — measure each thumbnail's aspect ratio from `<img>` `naturalWidth/Height` on load, render justified rows. Filename/size caption moved into a bottom **hover overlay** (an always-visible caption under each tile would break the equal row height).
- **Desktop album page** — same, via a new `.picg-thumbs-justified` grid in `DesktopChrome.tsx`. The edit-modal **cover picker keeps its square grid** (`.picg-thumbs`) untouched.

Aspect ratios are measured client-side (option A), so **no image-metadata changes** are needed. Unmeasured images use a 3:2 fallback and refine as they load (brief first-paint settle).

## Reviewer notes

- **Behavior change (web):** per-photo filename + size are now shown on hover rather than always-visible beneath each tile. Touch devices won't see them.
- Row tuning lives in constants: web `240px` / `12px` gap, desktop `200px` / `8px` gap (the CSS gap is kept in sync with the value passed to `computeJustifiedRows`).
- The published static gallery template (`src/templates/gallery-template.ts`) was intentionally **left unchanged** (scoped to the two management apps).
- Verified: `tsc --noEmit` clean, 6/6 unit tests pass, both routes compile, layout confirmed visually, and a local desktop build (`PicG.app`) runs with the new grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)