### PR TITLE
refactor(desktop): remove iCloud sync / migration feature

### DIFF
--- a/docs/desktop-development.md
+++ b/docs/desktop-development.md
@@ -99,18 +99,13 @@ Top-level operations that don't fit the per-gallery shape (`listRepos`,
 
 `electron/galleries/GalleryRegistry.ts` owns the user's gallery library.
 Manifests live at `<userData>/galleries.json`; cloned repos live at
-**either** `<userData>/galleries/<owner>__<repo>/` (default — Internal)
-**or** `~/Library/Mobile Documents/com~apple~CloudDocs/PicG/<owner>__<repo>/`
-(opt-in — iCloud, see §10). Users never see the path — the app is the
-library, not a folder picker over their filesystem.
+`<userData>/galleries/<owner>__<repo>/`. Users never see the path — the
+app is the library, not a folder picker over their filesystem.
 
 Methods: `list()` / `resolve(id)` / `clone(request, sender)` /
-`remove(id)` / `sync(id)` / `migrateToICloud(id, sender)` /
-`migrateToInternal(id, sender)` / `discoverICloud()` /
-`triggerICloudDownload(paths?)`. Clone and migrate progress stream
-over `CHANNELS.gallery.cloneProgress` and `.migrateProgress` events
-respectively; `measureDirSize` runs after clone + sync + migration to
-populate the capacity readout on cards.
+`remove(id)` / `sync(id)`. Clone progress streams over
+`CHANNELS.gallery.cloneProgress` events; `measureDirSize` runs after
+clone + sync to populate the capacity readout on cards.
 
 ### 1.3 `PreloadBridgeAdapter` (renderer → main)
 
@@ -611,7 +606,7 @@ To actually sign:
 5. Set `mac.identity` in `electron-builder.yml`, flip
    `hardenedRuntime: true`.
 
-Not yet done. Tracked in §11 backlog.
+Not yet done. Tracked in §10 backlog.
 
 ---
 
@@ -652,9 +647,9 @@ exits.
 
 Two competing requirements at push time:
 
-1. The OAuth token must NOT live in `.git/config`. iCloud sync, manual
-   backups, accidental commits — any of those can leak a long-lived
-   token out of a working tree.
+1. The OAuth token must NOT live in `.git/config`. Manual backups,
+   accidental commits — any of those can leak a long-lived token out
+   of a working tree.
 2. `refs/remotes/origin/<branch>` must update after a successful push,
    or the Topbar's ahead-counter looks stuck on N forever even though
    origin actually got the commits.
@@ -707,112 +702,7 @@ the user keeps their per-op Undo grain.
 
 ---
 
-## 10. iCloud sync (Mac-only)
-
-A gallery's working tree can live in the user's iCloud Drive instead
-of inside `<userData>`. iCloud Drive then handles cross-Mac sync of
-both the photo files and the `.git` directory; nothing else in the
-architecture changes — the same `LocalGitStorageAdapter` reads/writes
-through `fs/promises` regardless of where the path resolves to, and
-publishing still goes through `git push` → CI → deployed site as
-described in §0.
-
-### 10.1 Layout
-
-```
-~/Library/Mobile Documents/com~apple~CloudDocs/PicG/
-├── alice__landscape-2024/      ← gallery 1, full clone with .git
-└── alice__europe-trip/         ← gallery 2
-```
-
-`com~apple~CloudDocs` is the OS-mandated mount point for iCloud Drive
-on macOS; we hard-code it. The `PicG/` subfolder is intentionally
-literal — the user can find it in Finder / Files.app and recognize
-it. We don't use a bundle id like `com.lfkdsk.picg`.
-
-### 10.2 Migration
-
-`GalleryRegistry.migrateToICloud(id, sender)` (and its inverse
-`migrateToInternal`) copies the entire working tree to the new
-location, verifies the file count matches, atomically swaps
-`localPath` in the manifest, then deletes the source. Progress
-streams as `MigrateProgress` events on `CHANNELS.gallery.migrateProgress`
-through five phases: `counting → copying → verifying → cleanup → done`.
-The renderer (`/desktop/galleries`) renders the card's action row as a
-progress bar while a migrate is in flight.
-
-If anything fails before the manifest swap, the source is intact and
-we delete the half-copied destination so the user can retry. After
-the swap, source removal failure is logged but treated as recoverable
-garbage — the manifest already points to the new path so the user's
-view is correct.
-
-### 10.3 Discovery on startup
-
-`discoverICloud()` runs in `app.whenReady` (see [main.ts](../electron/main.ts))
-and scans `PicG/` for subdirectories whose name matches `<owner>__<repo>`,
-that contain a `.git/` directory, and whose `origin` remote points
-at `https://github.com/<owner>/<repo>(.git)?`. Folders that pass all
-three checks and aren't already in this Mac's manifest get
-auto-registered. Folders that fail any check are silently skipped and
-logged — better to miss a gallery than to import the user's stray
-folder.
-
-This is the mechanism that lets a gallery migrated on Mac A appear on
-Mac B without a re-clone. It's a one-shot at startup; we don't poll
-for newly-arrived iCloud folders during a session.
-
-### 10.4 Materialization (`brctl download`)
-
-iCloud's "Optimize Mac Storage" silently evicts files to placeholder
-form (`.foo.jpg.icloud`) when disk is tight, and **a placeholder breaks
-us** — `fs.readFile` returns `EIO`, sqlite errors, sharp can't decode.
-
-We mitigate two ways:
-
-- **At startup**, `triggerICloudDownload()` fires `brctl download
-  <path>` against every iCloud-rooted gallery in the manifest.
-  Already-downloaded files are no-ops; placeholders queue a
-  background materialization.
-- **After every migrate-to-iCloud**, the same call runs against the
-  new destination so the source-of-truth Mac doesn't immediately
-  hand its own files back to iCloud as placeholders.
-
-`brctl` is shell-out, fire-and-forget — we don't await its
-completion, only the queue acceptance. The right user-side fix is
-**System Settings → iCloud Drive → PicG folder → "Always Keep
-Downloaded"**; surfacing this hint in the UI is on the backlog.
-
-### 10.5 Known invariants
-
-- **Single-machine-at-a-time editing.** iCloud doesn't have Git's
-  conflict resolution. Concurrent edits on Mac A and Mac B before
-  iCloud finishes propagating produce silent `xxx 2.json` conflict
-  files in `.git/refs/` or working tree. Document; v1 has no UI for
-  detection.
-- **Always close the app before switching machines.** sqlite WAL
-  files (if any are left around by a future feature; current code
-  doesn't write sqlite from the desktop) and `.git/index.lock` need
-  to be committed/cleared before iCloud can sync them safely.
-- **No on-demand download.** v1 assumes the whole library is
-  materialized. A future enhancement can scan for `.icloud`
-  placeholders and lazy-download as the user navigates, with
-  thumbnail-level "downloading" overlays.
-
-### 10.6 Code paths
-
-| Concern | File |
-|---|---|
-| Registry methods | [`electron/galleries/GalleryRegistry.ts`](../electron/galleries/GalleryRegistry.ts) (search `iCloud`) |
-| IPC channels | [`electron/ipc/contract.ts`](../electron/ipc/contract.ts) — `gallery.migrate` / `discover` / `migrateProgress` / `iCloudRoot` |
-| IPC handlers | [`electron/ipc/gallery.ts`](../electron/ipc/gallery.ts) |
-| Preload bridge | [`electron/preload.ts`](../electron/preload.ts) |
-| Startup wiring | [`electron/main.ts`](../electron/main.ts) (`discoverICloud` + `triggerICloudDownload` after `app.whenReady`) |
-| Renderer UI | [`src/app/desktop/galleries/page.tsx`](../src/app/desktop/galleries/page.tsx) (storage badge, Move action, migrate progress) |
-
----
-
-## 11. Backlog / known gaps
+## 10. Backlog / known gaps
 
 These are deliberately undone, and listed here so the next person
 doesn't redo investigations.
@@ -857,26 +747,10 @@ doesn't redo investigations.
 - **Auto-update for dev builds** — `initAutoUpdater()` returns early
   when `!app.isPackaged`. There's no way to test the full update
   flow without packaging two builds and installing the older one.
-- **iCloud "Always Keep Downloaded" hint** — when the user moves a
-  gallery to iCloud (§10), we should prompt them to right-click the
-  PicG folder in Finder and pick "Always Keep Downloaded". Without
-  it, "Optimize Mac Storage" can evict files to placeholders and
-  break reads. `triggerICloudDownload` mitigates but doesn't prevent
-  re-eviction. UI for the hint is the missing piece.
-- **iCloud conflict file detection** — concurrent edits across two
-  Macs before iCloud finishes propagating produce silent
-  `xxx 2.json` / `xxx 2.jpg` conflict files. Detecting them on
-  startup and surfacing a "merge or discard" UI is on the iCloud
-  v2 list.
-- **On-demand iCloud download** — current code assumes the whole
-  library is materialized. A v2 enhancement scans for `.icloud`
-  placeholders during gallery navigation and lazy-downloads with
-  per-thumbnail "downloading" overlays, instead of the upfront
-  `brctl download` that we do today.
 
 ---
 
-## 12. File map cheat sheet
+## 11. File map cheat sheet
 
 ```
 electron/                                  Electron main process

--- a/electron/galleries/GalleryRegistry.ts
+++ b/electron/galleries/GalleryRegistry.ts
@@ -4,7 +4,6 @@
 // thin wrappers that translate calls and forward progress events.
 
 import { app, WebContents } from 'electron';
-import { exec } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import type { SimpleGit } from 'simple-git';
@@ -16,19 +15,10 @@ import type {
   CloneProgress,
   InFlightClone,
   LocalGallery,
-  MigrateDirection,
-  MigrateProgress,
 } from '../../src/core/storage/electron/galleryTypes';
-import { CHANNELS } from '../ipc/contract';
 
 const MANIFEST_FILE = 'galleries.json';
 const GALLERIES_DIR = 'galleries';
-
-// Sub-directory inside the user's iCloud Drive root where we store
-// galleries that opted in to cross-Mac sync. Picked to be visible and
-// recognizable in Files.app (on iPhone) and Finder. We deliberately
-// don't use a bundle id — iCloud Drive shows the literal folder name.
-const ICLOUD_PICG_DIR = 'PicG';
 
 // Marker thrown when clone() is cancelled by cancelClone(). Crosses IPC
 // as the error message; the renderer matches on this string to dismiss
@@ -69,7 +59,6 @@ export type CloneRequest = {
 export class GalleryRegistry {
   private readonly manifestPath: string;
   private readonly galleriesRoot: string;
-  private readonly iCloudRoot: string;
   private cache: LocalGallery[] | null = null;
   // In-flight clones, keyed by galleryId. Lives only in memory: clones
   // don't survive an app restart anyway (the simple-git child process
@@ -77,10 +66,6 @@ export class GalleryRegistry {
   // misleading. Used by listInFlight() so a renderer that mounts after
   // navigating back to /desktop/galleries can rebuild its progress UI.
   private readonly inFlight = new Map<string, InFlightClone>();
-  // Migrations currently running. We refuse to start a second migrate
-  // for a gallery that's already moving — the half-copied destination
-  // would race the in-progress copy and corrupt one or both.
-  private readonly migrating = new Set<string>();
   // AbortController per in-flight clone so cancelClone() can kill the
   // underlying simple-git child process. Separate map (not on the
   // InFlightClone struct) because controllers aren't structured-clone
@@ -91,40 +76,6 @@ export class GalleryRegistry {
     const userData = app.getPath('userData');
     this.manifestPath = path.join(userData, MANIFEST_FILE);
     this.galleriesRoot = path.join(userData, GALLERIES_DIR);
-    // ~/Library/Mobile Documents/com~apple~CloudDocs is iCloud Drive's
-    // canonical mount on macOS. The `com~apple~CloudDocs` token is
-    // hard-coded by Apple — it won't change, and there's no public API
-    // to discover it (FileProvider's API is iOS-only).
-    this.iCloudRoot = path.join(
-      app.getPath('home'),
-      'Library/Mobile Documents/com~apple~CloudDocs',
-      ICLOUD_PICG_DIR
-    );
-  }
-
-  iCloudGalleriesRoot(): string {
-    return this.iCloudRoot;
-  }
-
-  // Whether this absolute path lives under the iCloud Drive PicG folder.
-  // Used to derive `gallery.storage` on read. Tolerates trailing slashes
-  // and normalizes both inputs so a user who copied the path with a
-  // typo doesn't silently miss the check.
-  isICloudPath(p: string): boolean {
-    const root = path.resolve(this.iCloudRoot) + path.sep;
-    const candidate = path.resolve(p) + path.sep;
-    return candidate.startsWith(root);
-  }
-
-  // Add a transient `storage` field to a manifest entry without
-  // mutating the cached/persisted shape. Called from every public
-  // read path (list, resolve, clone return, sync return, migrate
-  // return) so the renderer always sees the right badge.
-  private decorate(g: LocalGallery): LocalGallery {
-    return {
-      ...g,
-      storage: this.isICloudPath(g.localPath) ? 'icloud' : 'internal',
-    };
   }
 
   // --- manifest ---
@@ -152,13 +103,13 @@ export class GalleryRegistry {
 
   async list(): Promise<LocalGallery[]> {
     const all = await this.readManifest();
-    return all.map((g) => this.decorate(g));
+    return all.map((g) => ({ ...g }));
   }
 
   async resolve(id: string): Promise<LocalGallery | null> {
     const all = await this.readManifest();
     const found = all.find((g) => g.id === id);
-    return found ? this.decorate(found) : null;
+    return found ? { ...found } : null;
   }
 
   // --- clone ---
@@ -296,7 +247,7 @@ export class GalleryRegistry {
     await this.writeManifest([...items, gallery]);
     this.inFlight.delete(id);
     this.cloneAborts.delete(id);
-    return this.decorate(gallery);
+    return { ...gallery };
   }
 
   // Snapshot of clones currently running. Used by the galleries page on
@@ -349,7 +300,7 @@ export class GalleryRegistry {
     const items = await this.readManifest();
     const next = items.map((g) => (g.id === id ? updated : g));
     await this.writeManifest(next);
-    return this.decorate(updated);
+    return { ...updated };
   }
 
   async push(id: string): Promise<PushReceipt> {
@@ -385,7 +336,7 @@ export class GalleryRegistry {
     // Two competing requirements for how we get the OAuth token to git:
     //
     //   (a) the token must NOT live in .git/config (would persist on
-    //       disk, leak via backups / iCloud sync / accidental commits)
+    //       disk, leak via backups / accidental commits)
     //   (b) `refs/remotes/origin/<branch>` must update after a push,
     //       otherwise the Topbar's ahead-counter looks stuck on N
     //       forever even though origin actually got the commits
@@ -679,412 +630,6 @@ export class GalleryRegistry {
       behind: s.behind,
       dirty: !s.isClean(),
     };
-  }
-
-  // --- iCloud migration ---
-
-  // Move a gallery's working tree into the user's iCloud Drive
-  // (`~/Library/Mobile Documents/com~apple~CloudDocs/PicG/<id>/`). The
-  // manifest's `localPath` is updated atomically — we copy first, verify,
-  // then swap the manifest, then delete the source. Failure at any step
-  // before the swap leaves the original directory intact, so the worst
-  // case is a half-written iCloud copy that we clean up before
-  // surfacing the error.
-  async migrateToICloud(
-    id: string,
-    sender: WebContents | null = null
-  ): Promise<LocalGallery> {
-    return this.migrate(id, 'to-icloud', sender);
-  }
-
-  // Reverse migration: pull a gallery out of iCloud back into the
-  // app's userData. Useful if the user is hitting iCloud quota issues
-  // or wants to stop syncing a particular library.
-  async migrateToInternal(
-    id: string,
-    sender: WebContents | null = null
-  ): Promise<LocalGallery> {
-    return this.migrate(id, 'to-internal', sender);
-  }
-
-  private async migrate(
-    id: string,
-    direction: MigrateDirection,
-    sender: WebContents | null
-  ): Promise<LocalGallery> {
-    if (this.migrating.has(id)) {
-      throw new Error(`Migration already in progress for ${id}`);
-    }
-    if (this.inFlight.has(id)) {
-      throw new Error(`Cannot migrate while a clone is running for ${id}`);
-    }
-    const gallery = await this.resolveRaw(id);
-    if (!gallery) throw new Error(`Gallery not found: ${id}`);
-
-    const isICloudNow = this.isICloudPath(gallery.localPath);
-    if (direction === 'to-icloud' && isICloudNow) {
-      throw new Error('Gallery already lives in iCloud Drive.');
-    }
-    if (direction === 'to-internal' && !isICloudNow) {
-      throw new Error('Gallery already lives in the app data directory.');
-    }
-
-    const dst =
-      direction === 'to-icloud'
-        ? path.join(this.iCloudRoot, id)
-        : path.join(this.galleriesRoot, id);
-
-    // Refuse to clobber an existing destination — if the user has a
-    // half-finished migration sitting in iCloud from a previous run,
-    // they should clean it up themselves rather than have us silently
-    // merge.
-    try {
-      await fs.access(dst);
-      throw new Error(
-        `Destination already exists: ${dst}. Remove it manually before retrying.`
-      );
-    } catch (err: any) {
-      if (err?.code !== 'ENOENT') throw err;
-    }
-
-    this.migrating.add(id);
-    const emit = (evt: MigrateProgress) => {
-      try {
-        sender?.send(CHANNELS.gallery.migrateProgress, evt);
-      } catch {
-        /* renderer might be gone; ignore */
-      }
-    };
-
-    try {
-      // Make sure the parent directory exists. For iCloud this also
-      // implicitly creates `~/.../com~apple~CloudDocs/PicG/` on first
-      // migration; the fileprovider materializes it as a real folder.
-      await fs.mkdir(path.dirname(dst), { recursive: true });
-
-      emit({ galleryId: id, direction, phase: 'counting' });
-      const entries = await this.listAll(gallery.localPath);
-      const totalFiles = entries.reduce((n, e) => (e.isDir ? n : n + 1), 0);
-      emit({
-        galleryId: id,
-        direction,
-        phase: 'counting',
-        total: totalFiles,
-      });
-
-      // Phase: copying. We mkdir the destination root first, then
-      // walk entries and copy each file. mkdir-on-each-file's parent
-      // is recursive+idempotent — a few extra cheap syscalls beat
-      // having to sort the entries list ourselves.
-      await fs.mkdir(dst, { recursive: true });
-      let processed = 0;
-      for (const entry of entries) {
-        const srcPath = path.join(gallery.localPath, entry.rel);
-        const dstPath = path.join(dst, entry.rel);
-        if (entry.isDir) {
-          await fs.mkdir(dstPath, { recursive: true });
-        } else {
-          await fs.mkdir(path.dirname(dstPath), { recursive: true });
-          await fs.copyFile(srcPath, dstPath);
-          processed += 1;
-          // Throttle progress to roughly one event per 25 files so
-          // the renderer's React reconciler doesn't melt on a
-          // 5000-photo migration. Always emit the final file.
-          if (processed % 25 === 0 || processed === totalFiles) {
-            emit({
-              galleryId: id,
-              direction,
-              phase: 'copying',
-              processed,
-              total: totalFiles,
-              current: entry.rel,
-            });
-          }
-        }
-      }
-
-      // Phase: verifying. Cheap sanity check — count files at the
-      // destination, must match the source's count we already
-      // computed. If a copyFile silently dropped a file (it doesn't,
-      // but defense in depth), we catch it before deleting the
-      // source.
-      emit({ galleryId: id, direction, phase: 'verifying', total: totalFiles });
-      const dstEntries = await this.listAll(dst);
-      const dstFiles = dstEntries.reduce((n, e) => (e.isDir ? n : n + 1), 0);
-      if (dstFiles !== totalFiles) {
-        throw new Error(
-          `Verification failed: source had ${totalFiles} files, destination has ${dstFiles}.`
-        );
-      }
-
-      // Atomically swap the manifest entry. Updating localPath is the
-      // commit point of the migration: from here on, every read goes
-      // through the new path. The old directory is just garbage we
-      // delete next.
-      const items = await this.readManifest();
-      const updated: LocalGallery = { ...gallery, localPath: dst };
-      const next = items.map((g) => (g.id === id ? updated : g));
-      await this.writeManifest(next);
-
-      emit({ galleryId: id, direction, phase: 'cleanup' });
-      await fs.rm(gallery.localPath, { recursive: true, force: true }).catch(
-        (err) => {
-          // Source removal failed but the manifest is already pointing
-          // at the new path, so the user's experience is correct.
-          // Surface to console for the spike — orphaned source is
-          // recoverable manually.
-          console.warn(
-            `[picg] migrate: failed to remove source ${gallery.localPath}: ${
-              err?.message ?? err
-            }`
-          );
-        }
-      );
-
-      // For migrations into iCloud, kick off `brctl download` on the
-      // new path so the file provider materializes it on this Mac
-      // immediately instead of lazily. Async — we don't block the
-      // UI on the download finishing.
-      if (direction === 'to-icloud') {
-        this.triggerICloudDownload([dst]).catch(() => {
-          /* logged inside */
-        });
-      }
-
-      emit({
-        galleryId: id,
-        direction,
-        phase: 'done',
-        processed: totalFiles,
-        total: totalFiles,
-      });
-      return this.decorate(updated);
-    } catch (err) {
-      // Best-effort cleanup of the half-copied destination. If it
-      // doesn't exist (we never got past mkdir) the rm is a no-op.
-      await fs.rm(dst, { recursive: true, force: true }).catch(() => {});
-      const message = err instanceof Error ? err.message : String(err);
-      emit({ galleryId: id, direction, phase: 'error', error: message });
-      throw err;
-    } finally {
-      this.migrating.delete(id);
-    }
-  }
-
-  // Scan ~/.../PicG/ for galleries that aren't in this machine's
-  // manifest. Used at startup so a gallery the user migrated to
-  // iCloud on Mac A automatically shows up on Mac B without re-cloning.
-  //
-  // Discovery is conservative: a folder qualifies if it (a) has a
-  // `.git` directory, (b) has a remote named `origin`, and (c) the
-  // remote URL parses as a GitHub https clone URL. Anything else is
-  // ignored — better to miss a gallery than to add a stray folder
-  // the user dropped in PicG/ for some other reason.
-  //
-  // Returns the newly-added gallery records (decorated). Empty array
-  // means nothing changed.
-  async discoverICloud(): Promise<LocalGallery[]> {
-    let entries: string[];
-    try {
-      const dirents = await fs.readdir(this.iCloudRoot, { withFileTypes: true });
-      entries = dirents.filter((d) => d.isDirectory()).map((d) => d.name);
-    } catch (err: any) {
-      // ENOENT = no PicG folder yet (first launch on this machine, or
-      // user never migrated anything to iCloud). Not an error.
-      if (err?.code === 'ENOENT') return [];
-      throw err;
-    }
-
-    const existing = await this.readManifest();
-    const seen = new Set(existing.map((g) => g.id));
-    const additions: LocalGallery[] = [];
-
-    for (const id of entries) {
-      if (seen.has(id)) continue;
-      const candidate = path.join(this.iCloudRoot, id);
-      const gallery = await this.tryRecognizeGallery(id, candidate).catch(
-        (err) => {
-          console.warn(
-            `[picg] discoverICloud: skipping ${candidate}: ${
-              err?.message ?? err
-            }`
-          );
-          return null;
-        }
-      );
-      if (gallery) additions.push(gallery);
-    }
-
-    if (additions.length === 0) return [];
-
-    const next = [...existing, ...additions];
-    await this.writeManifest(next);
-    return additions.map((g) => this.decorate(g));
-  }
-
-  // Recognize a directory as a PicG gallery and produce a manifest
-  // entry for it. Reads the git remote to derive owner / repo / clone
-  // URL; rejects anything that doesn't look like a GitHub https remote
-  // (`https://github.com/<owner>/<repo>.git`). Folder name must
-  // already match `<owner>__<repo>` since that's our manifest id.
-  private async tryRecognizeGallery(
-    id: string,
-    dirPath: string
-  ): Promise<LocalGallery | null> {
-    // Parse `<owner>__<repo>` from the folder name. We never silently
-    // synthesize an id from the remote, because the folder name is
-    // what determines our manifest key — getting it from somewhere
-    // else risks two manifest entries for the same on-disk folder.
-    const sep = id.indexOf('__');
-    if (sep <= 0 || sep === id.length - 2) return null;
-    const owner = id.slice(0, sep);
-    const repo = id.slice(sep + 2);
-
-    // Confirm `.git` exists. Without it, this isn't a clone — could
-    // be a stray folder the user created.
-    try {
-      const gitStat = await fs.stat(path.join(dirPath, '.git'));
-      if (!gitStat.isDirectory()) return null;
-    } catch {
-      return null;
-    }
-
-    let remoteUrl = '';
-    try {
-      const probe = await buildIsolatedGit(dirPath);
-      remoteUrl = (await probe.remote(['get-url', 'origin']))
-        ?.toString()
-        .trim() ?? '';
-    } catch {
-      return null;
-    }
-    if (!remoteUrl) return null;
-
-    // Accept https://github.com/<owner>/<repo>(.git)? — we don't
-    // support ssh remotes for cloning anyway (token-based https is
-    // the entire auth model in clone()).
-    const m = remoteUrl.match(
-      /^https:\/\/github\.com\/([^\/]+)\/([^\/]+?)(?:\.git)?\/?$/
-    );
-    if (!m) return null;
-    const [, remoteOwner, remoteRepo] = m;
-    if (remoteOwner !== owner || remoteRepo !== repo) {
-      // Folder name disagrees with the remote — refuse rather than
-      // silently importing under the wrong id.
-      return null;
-    }
-
-    // Best-effort default branch: ask git for HEAD's branch. simpleGit
-    // returns empty when on a detached HEAD; we leave defaultBranch
-    // undefined in that case rather than guessing.
-    let defaultBranch: string | undefined;
-    try {
-      const probe = await buildIsolatedGit(dirPath);
-      const branchInfo = await probe.branch();
-      defaultBranch = branchInfo.current || undefined;
-    } catch {
-      /* leave undefined */
-    }
-
-    const sizeBytes = await measureDirSize(dirPath).catch(() => 0);
-
-    return {
-      id,
-      owner,
-      repo,
-      fullName: `${owner}/${repo}`,
-      htmlUrl: `https://github.com/${owner}/${repo}`,
-      cloneUrl: `https://github.com/${owner}/${repo}.git`,
-      localPath: dirPath,
-      defaultBranch,
-      addedAt: new Date().toISOString(),
-      sizeBytes,
-    };
-  }
-
-  // Fire `brctl download` for one or more iCloud paths. Async,
-  // non-blocking — `brctl` returns when the file provider has queued
-  // the download, not when it's finished. Treats failures as warnings
-  // because brctl might be missing on a stripped macOS install or
-  // the user might not be signed into iCloud; either way we continue.
-  //
-  // If `paths` is undefined, downloads every gallery currently in the
-  // manifest whose localPath is under iCloud — used at startup.
-  async triggerICloudDownload(paths?: string[]): Promise<void> {
-    let targets: string[];
-    if (paths) {
-      targets = paths;
-    } else {
-      const all = await this.readManifest();
-      targets = all
-        .filter((g) => this.isICloudPath(g.localPath))
-        .map((g) => g.localPath);
-    }
-    if (targets.length === 0) return;
-
-    await Promise.all(
-      targets.map(
-        (p) =>
-          new Promise<void>((resolve) => {
-            // brctl is a single-arg CLI: `brctl download <path>`. We
-            // shell-out via exec rather than spawn because the path
-            // is from our own manifest (never user-controlled at this
-            // layer) and exec lets us shell-quote with one argument
-            // string. JSON.stringify gives us a properly-quoted shell
-            // string for any path, including ones with spaces or
-            // single quotes.
-            exec(
-              `brctl download ${JSON.stringify(p)}`,
-              { timeout: 60_000 },
-              (err) => {
-                if (err) {
-                  console.warn(
-                    `[picg] brctl download failed for ${p}: ${err.message}`
-                  );
-                }
-                resolve();
-              }
-            );
-          })
-      )
-    );
-  }
-
-  // Like resolve() but returns the persisted shape (no `storage`
-  // decoration). Internal helper for migrate, which needs the bare
-  // record so the next writeManifest doesn't accidentally persist the
-  // derived field.
-  private async resolveRaw(id: string): Promise<LocalGallery | null> {
-    const all = await this.readManifest();
-    return all.find((g) => g.id === id) ?? null;
-  }
-
-  // Recursive directory walk, returning entries in a flat list keyed
-  // by their relative path. Used by migrate() to count files for
-  // progress and to drive the copy. Skips symlinks (gallery contents
-  // are photos + git objects, neither of which the renderer can
-  // create).
-  private async listAll(
-    root: string
-  ): Promise<{ rel: string; isDir: boolean }[]> {
-    const out: { rel: string; isDir: boolean }[] = [];
-    const stack: string[] = [''];
-    while (stack.length > 0) {
-      const cur = stack.pop()!;
-      const dir = cur ? path.join(root, cur) : root;
-      const entries = await fs.readdir(dir, { withFileTypes: true });
-      for (const e of entries) {
-        const rel = cur ? path.join(cur, e.name) : e.name;
-        if (e.isDirectory()) {
-          out.push({ rel, isDir: true });
-          stack.push(rel);
-        } else if (e.isFile()) {
-          out.push({ rel, isDir: false });
-        }
-        // symlinks intentionally skipped — see method comment
-      }
-    }
-    return out;
   }
 }
 

--- a/electron/ipc/contract.ts
+++ b/electron/ipc/contract.ts
@@ -16,8 +16,6 @@ import type {
   CloneProgress,
   InFlightClone,
   LocalGallery,
-  MigrateDirection,
-  MigrateProgress,
 } from '../../src/core/storage/electron/galleryTypes';
 
 export const CHANNELS = {
@@ -72,10 +70,6 @@ export const CHANNELS = {
     refreshStatus: 'gallery:refresh-status',
     cloneProgress: 'gallery:clone-progress',
     undoLastCommit: 'gallery:undo-last-commit',
-    migrate: 'gallery:migrate',
-    discover: 'gallery:discover',
-    migrateProgress: 'gallery:migrate-progress',
-    iCloudRoot: 'gallery:icloud-root',
     // Main → renderer broadcast: a gallery's git state changed in a
     // way that probably affects ahead/behind/dirty. Fired after every
     // mutation handler in storage.ts (write/delete) and after pull /
@@ -114,8 +108,6 @@ export type GalleryCloneArgs = [
     defaultBranch?: string;
   },
 ];
-
-export type GalleryMigrateArgs = [id: string, direction: MigrateDirection];
 
 // Wire format for FileContent. The renderer-side adapter rehydrates this into
 // a FileContent (with `text()` / `base64()` helpers) — those methods can't
@@ -210,11 +202,7 @@ export type GalleryChangedEvent = {
     | 'delete-dir'
     | 'pull'
     | 'push'
-    | 'undo'
-    // Background iCloud discovery added new galleries to the manifest
-    // after the window already loaded. Carries no galleryId/repoPath —
-    // it's a bulk manifest change, so list views refetch wholesale.
-    | 'discover';
+    | 'undo';
 };
 
 // Returned by gallery.undoLastCommit. `reverted` is the subject line of
@@ -361,10 +349,6 @@ export interface PicgBridge {
     refreshStatus(id: string): Promise<GalleryStatus>;
     undoLastCommit(id: string): Promise<UndoResult>;
     onCloneProgress(handler: (event: CloneProgress) => void): () => void;
-    migrate(...args: GalleryMigrateArgs): Promise<LocalGallery>;
-    discover(): Promise<LocalGallery[]>;
-    iCloudRoot(): Promise<string>;
-    onMigrateProgress(handler: (event: MigrateProgress) => void): () => void;
     // Subscribe to git-state-change broadcasts. See CHANNELS.gallery.changed.
     onChanged(handler: (event: GalleryChangedEvent) => void): () => void;
   };

--- a/electron/ipc/gallery.ts
+++ b/electron/ipc/gallery.ts
@@ -9,7 +9,7 @@ import { ipcMain } from 'electron';
 import { GalleryRegistry } from '../galleries/GalleryRegistry';
 import { CHANNELS } from './contract';
 import { emitGalleryChanged } from './events';
-import type { GalleryCloneArgs, GalleryMigrateArgs } from './contract';
+import type { GalleryCloneArgs } from './contract';
 
 // Module-level singleton, exported so the picg:// protocol handler in
 // main.ts can use the SAME instance (and therefore the same cache).
@@ -102,31 +102,5 @@ export function registerGalleryIpcHandlers(): void {
       });
     }
     return result;
-  });
-
-  // Migration is the only gallery op besides clone that streams progress.
-  // We pass `event.sender` so the registry can broadcast
-  // CHANNELS.gallery.migrateProgress events back to the requesting
-  // renderer, exactly matching the clone-progress pattern.
-  ipcMain.handle(
-    CHANNELS.gallery.migrate,
-    async (event, ...args: GalleryMigrateArgs) => {
-      const [id, direction] = args;
-      const registry = getRegistry();
-      return direction === 'to-icloud'
-        ? registry.migrateToICloud(id, event.sender)
-        : registry.migrateToInternal(id, event.sender);
-    }
-  );
-
-  ipcMain.handle(CHANNELS.gallery.discover, async () => {
-    return getRegistry().discoverICloud();
-  });
-
-  // Renderer-visible iCloud root path. The galleries page uses this
-  // for the "iCloud-syncing libraries live in <path>" hint in the
-  // settings menu, so the user can find them in Finder if they need to.
-  ipcMain.handle(CHANNELS.gallery.iCloudRoot, async () => {
-    return getRegistry().iCloudGalleriesRoot();
   });
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,7 +34,6 @@ import { registerAuthIpcHandlers } from './ipc/auth';
 import { registerCompressIpcHandlers } from './ipc/compress';
 import { getRegistry, registerGalleryIpcHandlers } from './ipc/gallery';
 import { registerStorageIpcHandlers } from './ipc/storage';
-import { emitGalleryChanged } from './ipc/events';
 
 // `picg://oauth/#oauth_token=...` is the redirect URL the lfkdsk-auth
 // Worker hands back after a desktop sign-in. macOS routes that to this
@@ -574,40 +573,7 @@ app.whenReady().then(async () => {
     }
   });
 
-  // Open the window FIRST, before any iCloud work. discoverICloud()
-  // probes each not-yet-known iCloud gallery with git, and those reads
-  // BLOCK while macOS materializes the repo's `.git` objects from iCloud.
-  // When the files haven't synced down (offline, or the file provider
-  // stalls) the read never returns — and because this used to be
-  // `await`ed ahead of createWindow(), the whole window failed to appear.
-  // Creating the window up front guarantees the UI always opens; iCloud
-  // discovery runs in the background and refreshes the list when done.
   createWindow();
-
-  // iCloud bootstrap (background, best-effort): pick up galleries another
-  // Mac migrated to ~/Library/Mobile Documents/com~apple~CloudDocs/PicG/
-  // that this machine's manifest doesn't know about yet, and kick off a
-  // `brctl download` for every iCloud-rooted entry so files materialize
-  // on disk for later reads. Deliberately NOT awaited on the startup path.
-  void (async () => {
-    try {
-      const added = await galleryRegistry.discoverICloud();
-      if (added.length > 0) {
-        console.log(`[picg] discovered ${added.length} iCloud gallery(ies)`);
-        // The galleries list already rendered (and ran its initial
-        // list()) before discovery finished, so it's missing these.
-        // Broadcast so any open list view refetches the manifest.
-        emitGalleryChanged({ cause: 'discover' });
-      }
-    } catch (err) {
-      console.warn('[picg] iCloud discovery failed', err);
-    }
-    // `brctl download` only queues work in the file provider; nothing
-    // here waits for completion. Runs even if discovery threw above.
-    galleryRegistry.triggerICloudDownload().catch((err) => {
-      console.warn('[picg] triggerICloudDownload failed', err);
-    });
-  })();
 
   // If the user clicked a picg:// link before the app was running, we
   // captured the URL but had nowhere to send it; now there's a window.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,10 +11,7 @@ import type {
   OAuthCallbackPayload,
   PicgBridge,
 } from './ipc/contract';
-import type {
-  CloneProgress,
-  MigrateProgress,
-} from '../src/core/storage/electron/galleryTypes';
+import type { CloneProgress } from '../src/core/storage/electron/galleryTypes';
 
 const bridge: PicgBridge = {
   pickGalleryDir: () => ipcRenderer.invoke(CHANNELS.pickGalleryDir),
@@ -76,14 +73,6 @@ const bridge: PicgBridge = {
       const listener = (_e: unknown, evt: CloneProgress) => handler(evt);
       ipcRenderer.on(CHANNELS.gallery.cloneProgress, listener);
       return () => ipcRenderer.off(CHANNELS.gallery.cloneProgress, listener);
-    },
-    migrate: (...args) => ipcRenderer.invoke(CHANNELS.gallery.migrate, ...args),
-    discover: () => ipcRenderer.invoke(CHANNELS.gallery.discover),
-    iCloudRoot: () => ipcRenderer.invoke(CHANNELS.gallery.iCloudRoot),
-    onMigrateProgress: (handler: (event: MigrateProgress) => void) => {
-      const listener = (_e: unknown, evt: MigrateProgress) => handler(evt);
-      ipcRenderer.on(CHANNELS.gallery.migrateProgress, listener);
-      return () => ipcRenderer.off(CHANNELS.gallery.migrateProgress, listener);
     },
     onChanged: (handler: (event: GalleryChangedEvent) => void) => {
       const listener = (_e: unknown, evt: GalleryChangedEvent) => handler(evt);

--- a/src/app/desktop/galleries/[id]/page.tsx
+++ b/src/app/desktop/galleries/[id]/page.tsx
@@ -9,8 +9,6 @@ import {
   PreloadBridgeAdapter,
   getPicgBridge,
   type LocalGallery,
-  type MigrateDirection,
-  type MigrateProgress,
   type PicgBridge,
   type PushReceipt,
   type StorageAdapter,
@@ -88,12 +86,6 @@ export default function GalleryDetailPage() {
   // Cleared on dismiss or when this gallery unloads. See
   // PushReceiptCard for the rendered shape.
   const [pushReceipt, setPushReceipt] = useState<PushReceipt | null>(null);
-  // Storage migration (move between userData and iCloud Drive). Lives
-  // on the detail page rather than the list card so it's harder to
-  // mis-tap — every successful trigger has gone through "open the
-  // gallery, open the menu, click confirm" first. MigrateState type is
-  // declared at module scope alongside MigrateModal.
-  const [migrateState, setMigrateState] = useState<MigrateState | null>(null);
 
   useEffect(() => {
     setBridge(getPicgBridge());
@@ -456,24 +448,6 @@ export default function GalleryDetailPage() {
                       >
                         Shrink oversized photos
                       </Link>
-                      <div className="picg-menu-divider" />
-                      <button
-                        type="button"
-                        className="picg-menu-item"
-                        onClick={() => {
-                          setMoreMenuOpen(false);
-                          setMigrateState({
-                            phase: 'confirm',
-                            direction:
-                              gallery.storage === 'icloud' ? 'to-internal' : 'to-icloud',
-                          });
-                        }}
-                        role="menuitem"
-                      >
-                        {gallery.storage === 'icloud'
-                          ? 'Move to internal storage…'
-                          : 'Move to iCloud Drive…'}
-                      </button>
                     </div>
                   </>
                 )}
@@ -566,19 +540,6 @@ export default function GalleryDetailPage() {
         open={editGalleryOpen}
         onClose={() => setEditGalleryOpen(false)}
       />
-
-      {migrateState && bridge && (
-        <MigrateModal
-          state={migrateState}
-          gallery={gallery}
-          bridge={bridge}
-          onUpdate={(next) => setMigrateState(next)}
-          onResolved={(updated) => {
-            // Refresh local gallery state with the post-migration shape.
-            setGallery(updated);
-          }}
-        />
-      )}
 
       <UndoToastHost />
       <DesktopTheme />
@@ -771,273 +732,6 @@ function AlbumCard({
           {album.location[0].toFixed(4)}, {album.location[1].toFixed(4)}
         </div>
       )}
-    </div>
-  );
-}
-
-type MigrateState =
-  | { phase: 'confirm'; direction: MigrateDirection }
-  | { phase: 'running'; direction: MigrateDirection; progress: MigrateProgress | null }
-  | { phase: 'error'; direction: MigrateDirection; error: string }
-  | { phase: 'done'; direction: MigrateDirection };
-
-function MigrateModal({
-  state,
-  gallery,
-  bridge,
-  onUpdate,
-  onResolved,
-}: {
-  state: MigrateState;
-  gallery: LocalGallery;
-  bridge: PicgBridge;
-  onUpdate: (next: MigrateState | null) => void;
-  onResolved: (updated: LocalGallery) => void;
-}) {
-  // Subscribe to migrate-progress events for the duration of the
-  // running phase. Effect re-runs when phase changes; cleanup ensures
-  // we don't leak subscriptions across phase transitions.
-  useEffect(() => {
-    if (state.phase !== 'running') return;
-    const unsub = bridge.gallery.onMigrateProgress((evt) => {
-      if (evt.galleryId !== gallery.id) return;
-      onUpdate({ ...state, progress: evt });
-    });
-    return () => unsub();
-  }, [state, bridge, gallery.id, onUpdate]);
-
-  const isToICloud = state.direction === 'to-icloud';
-  const targetLabel = isToICloud ? 'iCloud Drive' : 'internal storage';
-  const fromLabel = isToICloud ? 'internal storage' : 'iCloud Drive';
-
-  const startMigrate = async () => {
-    onUpdate({ phase: 'running', direction: state.direction, progress: null });
-    try {
-      const updated = await bridge.gallery.migrate(gallery.id, state.direction);
-      onResolved(updated);
-      onUpdate({ phase: 'done', direction: state.direction });
-    } catch (err) {
-      onUpdate({
-        phase: 'error',
-        direction: state.direction,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  };
-
-  const close = () => onUpdate(null);
-  // Block backdrop close while running so the user doesn't accidentally
-  // dismiss the in-flight progress; other phases close on backdrop click.
-  const onBackdropClick = () => {
-    if (state.phase === 'running') return;
-    close();
-  };
-
-  return (
-    <div className="picg-modal-backdrop" onClick={onBackdropClick} role="dialog">
-      <div
-        className="picg-modal picg-migrate-modal"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {state.phase === 'confirm' && (
-          <>
-            <header className="picg-modal-header">
-              <div className="picg-modal-title-wrap">
-                <h2>{isToICloud ? 'Move to iCloud Drive' : 'Move to internal storage'}</h2>
-              </div>
-              <button
-                type="button"
-                className="btn ghost icon"
-                onClick={close}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </header>
-            <div className="body">
-              <p>
-                This will copy <strong>{gallery.fullName}</strong> from {fromLabel} to {targetLabel}.
-                {isToICloud ? (
-                  <> Once done, your other Macs signed into the same iCloud account will see this gallery automatically.</>
-                ) : (
-                  <> Once done, the gallery will live only on this Mac and stop syncing.</>
-                )}
-              </p>
-              <p className="warn">
-                The copy can take several minutes for a large gallery (every photo is duplicated, then the original is removed). PicG can stay open during the move.
-              </p>
-            </div>
-            <div className="picg-modal-actions">
-              <button type="button" className="btn ghost" onClick={close}>
-                Cancel
-              </button>
-              <button
-                type="button"
-                className={`btn primary${isToICloud ? '' : ' danger'}`}
-                onClick={startMigrate}
-              >
-                {isToICloud ? 'Move to iCloud' : 'Move to internal'}
-              </button>
-            </div>
-          </>
-        )}
-
-        {state.phase === 'running' && (
-          <>
-            <header className="picg-modal-header">
-              <div className="picg-modal-title-wrap">
-                <h2>Moving to {targetLabel}…</h2>
-              </div>
-            </header>
-            <div className="body">
-              <MigrateProgressView progress={state.progress} />
-              <p className="warn">
-                Don&apos;t quit PicG while this runs. You can keep using other galleries.
-              </p>
-            </div>
-          </>
-        )}
-
-        {state.phase === 'error' && (
-          <>
-            <header className="picg-modal-header">
-              <div className="picg-modal-title-wrap">
-                <h2>Move failed</h2>
-              </div>
-              <button
-                type="button"
-                className="btn ghost icon"
-                onClick={close}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </header>
-            <div className="body">
-              <div className="picg-banner">{state.error}</div>
-            </div>
-            <div className="picg-modal-actions">
-              <button type="button" className="btn ghost" onClick={close}>
-                Close
-              </button>
-              <button type="button" className="btn primary" onClick={startMigrate}>
-                Retry
-              </button>
-            </div>
-          </>
-        )}
-
-        {state.phase === 'done' && (
-          <>
-            <header className="picg-modal-header">
-              <div className="picg-modal-title-wrap">
-                <h2>Moved to {targetLabel}</h2>
-              </div>
-              <button
-                type="button"
-                className="btn ghost icon"
-                onClick={close}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </header>
-            <div className="body">
-              <p>
-                <strong>{gallery.fullName}</strong> now lives in {targetLabel}.
-              </p>
-            </div>
-            <div className="picg-modal-actions">
-              <button type="button" className="btn primary" onClick={close}>
-                Done
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-
-      <style jsx>{`
-        .body {
-          padding: 4px 0 16px;
-          font-size: 14px;
-          color: var(--text);
-          line-height: 1.5;
-        }
-        .body p { margin: 0 0 12px; }
-        .body p:last-child { margin-bottom: 0; }
-        .body .warn {
-          font-family: var(--mono);
-          font-size: 12px;
-          color: var(--text-muted);
-          letter-spacing: 0.02em;
-        }
-      `}</style>
-    </div>
-  );
-}
-
-function MigrateProgressView({ progress }: { progress: MigrateProgress | null }) {
-  const total = progress?.total ?? 0;
-  const processed = progress?.processed ?? 0;
-  const pct = total > 0 ? (processed / total) * 100 : 0;
-  const phase = progress?.phase ?? 'counting';
-  const phaseLabel =
-    phase === 'counting' ? 'Counting files'
-    : phase === 'copying' ? 'Copying'
-    : phase === 'verifying' ? 'Verifying'
-    : phase === 'cleanup' ? 'Cleaning up source'
-    : phase === 'done' ? 'Done'
-    : phase === 'error' ? 'Error'
-    : phase;
-  return (
-    <div className="prog">
-      <div className="head">
-        <span>{phaseLabel}</span>
-        {total > 0 && (
-          <span className="count">
-            {processed.toLocaleString()} / {total.toLocaleString()} files
-          </span>
-        )}
-      </div>
-      <div className="bar"><span style={{ width: `${pct}%` }} /></div>
-      {progress?.current && (
-        <div className="cur" title={progress.current}>
-          {progress.current}
-        </div>
-      )}
-      <style jsx>{`
-        .prog { margin: 8px 0 12px; }
-        .head {
-          display: flex; justify-content: space-between; align-items: baseline;
-          gap: 12px; margin-bottom: 8px;
-          font-family: var(--mono);
-          font-size: 12px;
-          color: var(--text);
-          letter-spacing: 0.04em;
-        }
-        .count { color: var(--text-muted); }
-        .bar {
-          height: 4px;
-          background: var(--border);
-          border-radius: 2px;
-          overflow: hidden;
-        }
-        .bar span {
-          display: block;
-          height: 100%;
-          background: var(--accent);
-          transition: width 0.25s ease;
-        }
-        .cur {
-          margin-top: 10px;
-          font-family: var(--mono);
-          font-size: 11px;
-          color: var(--text-muted);
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/desktop/galleries/page.tsx
+++ b/src/app/desktop/galleries/page.tsx
@@ -12,11 +12,7 @@ import {
   type PicgBridge,
   type Repo,
 } from '@/core/storage';
-import type {
-  InFlightClone,
-  MigrateDirection,
-  MigrateProgress,
-} from '@/core/storage';
+import type { InFlightClone } from '@/core/storage';
 import { getGitHubToken } from '@/lib/github';
 import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 
@@ -76,13 +72,6 @@ export default function GalleriesPage() {
       { fullName: string; htmlUrl?: string; progress?: CloneProgress; error?: string }
     >
   >({});
-  // In-flight migrations keyed by galleryId. We render the card's
-  // action row as a progress bar + phase label while present, and
-  // restore the normal Sync / Move / Remove row once the entry is
-  // cleared (on success or after the user dismisses an error).
-  const [migrating, setMigrating] = useState<
-    Record<string, { direction: MigrateDirection; progress?: MigrateProgress; error?: string }>
-  >({});
   const [pickerOpen, setPickerOpen] = useState(false);
   const [repos, setRepos] = useState<Repo[] | null>(null);
   const [loadingRepos, setLoadingRepos] = useState(false);
@@ -133,19 +122,6 @@ export default function GalleriesPage() {
       });
   }, [bridge]);
 
-  // Background iCloud discovery in main can add galleries to the manifest
-  // after this page already ran its initial list(). It broadcasts
-  // gallery.changed with cause 'discover'; refetch so those galleries
-  // appear without a manual reload.
-  useEffect(() => {
-    if (!bridge) return;
-    const unsub = bridge.gallery.onChanged((evt) => {
-      if (evt.cause !== 'discover') return;
-      bridge.gallery.list().then(setGalleries).catch(() => {});
-    });
-    return unsub;
-  }, [bridge]);
-
   useEffect(() => {
     if (!bridge) return;
     const unsub = bridge.gallery.onCloneProgress((evt) => {
@@ -172,34 +148,6 @@ export default function GalleriesPage() {
             progress: evt,
           },
         };
-      });
-    });
-    return unsub;
-  }, [bridge]);
-
-  useEffect(() => {
-    if (!bridge) return;
-    const unsub = bridge.gallery.onMigrateProgress((evt) => {
-      // Migration is now triggered from the gallery detail page, but we
-      // still listen here so a user navigating back mid-flight can see
-      // progress on the card. On terminal phases, refetch the manifest
-      // so the storage badge / size flip to the post-migration state,
-      // and clear the in-flight entry so the card stops showing "100%
-      // moving to iCloud" indefinitely.
-      if (evt.phase === 'done' || evt.phase === 'error') {
-        bridge.gallery
-          .list()
-          .then((fresh) => setGalleries(fresh))
-          .catch(() => {});
-        setMigrating((prev) => {
-          const { [evt.galleryId]: _removed, ...rest } = prev;
-          return rest;
-        });
-        return;
-      }
-      setMigrating((prev) => {
-        const entry = prev[evt.galleryId] ?? { direction: evt.direction };
-        return { ...prev, [evt.galleryId]: { ...entry, progress: evt } };
       });
     });
     return unsub;
@@ -305,47 +253,6 @@ export default function GalleriesPage() {
     } catch (err) {
       setError(`Remove failed: ${err instanceof Error ? err.message : err}`);
     }
-  }
-
-  async function handleMigrate(id: string, direction: MigrateDirection) {
-    if (!bridge) return;
-    const isToICloud = direction === 'to-icloud';
-    const confirmText = isToICloud
-      ? 'Move this gallery into your iCloud Drive? It will sync to your other Macs automatically.'
-      : 'Move this gallery out of iCloud back to local-only storage on this Mac?';
-    if (!confirm(confirmText)) return;
-
-    setMigrating((prev) => ({ ...prev, [id]: { direction } }));
-    try {
-      const updated = await bridge.gallery.migrate(id, direction);
-      setGalleries((prev) => prev.map((g) => (g.id === id ? updated : g)));
-      // Clear the migrating entry on success — the renderer will
-      // immediately render the post-migration state (new badge,
-      // restored Sync / Move / Remove row).
-      setMigrating((prev) => {
-        const { [id]: _removed, ...rest } = prev;
-        return rest;
-      });
-    } catch (err) {
-      // Leave the entry in place with an error; the user dismisses
-      // it explicitly so they have time to read what failed (network,
-      // disk space, destination already exists, …).
-      setMigrating((prev) => ({
-        ...prev,
-        [id]: {
-          ...prev[id],
-          direction,
-          error: err instanceof Error ? err.message : String(err),
-        },
-      }));
-    }
-  }
-
-  function dismissMigrate(id: string) {
-    setMigrating((prev) => {
-      const { [id]: _removed, ...rest } = prev;
-      return rest;
-    });
   }
 
   function dismissError(id: string) {
@@ -475,86 +382,32 @@ export default function GalleriesPage() {
             );
           })}
 
-          {galleries.map((g) => {
-            const m = migrating[g.id];
-            const phase = m?.progress?.phase;
-            const phaseLabel = phase
-              ? phase === 'counting'
-                ? 'preparing'
-                : phase === 'copying'
-                ? 'copying files'
-                : phase === 'verifying'
-                ? 'verifying'
-                : phase === 'cleanup'
-                ? 'cleaning up'
-                : phase
-              : 'starting…';
-            const processed = m?.progress?.processed ?? 0;
-            const totalFiles = m?.progress?.total ?? 0;
-            const pct = totalFiles > 0 ? Math.min(100, (processed / totalFiles) * 100) : 0;
-            return (
-              <li key={g.id} className="card">
-                <Link href={`/desktop/galleries/${g.id}`} className="picg-card-link">
-                  <div className="card-title">{g.fullName}</div>
-                </Link>
-                <div className="card-meta">
-                  <span>{formatBytes(g.sizeBytes)}</span>
-                  <span className="dot">•</span>
-                  <span className={`storage-tag ${g.storage ?? 'internal'}`}>
-                    {g.storage === 'icloud' ? 'iCloud' : 'Internal'}
-                  </span>
-                  {g.defaultBranch && (
-                    <>
-                      <span className="dot">•</span>
-                      <span>{g.defaultBranch}</span>
-                    </>
-                  )}
-                  {g.lastSyncAt && (
-                    <>
-                      <span className="dot">•</span>
-                      <span>synced {formatRelativeTime(g.lastSyncAt)}</span>
-                    </>
-                  )}
-                </div>
-                {m ? (
-                  m.error ? (
-                    <>
-                      <div className="error-text">{m.error}</div>
-                      <div className="card-actions">
-                        <button onClick={() => dismissMigrate(g.id)} className="btn ghost small">
-                          dismiss
-                        </button>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="bar"><div className="bar-fill" style={{ width: `${pct}%` }} /></div>
-                      <div className="card-meta">
-                        <span>
-                          {m.direction === 'to-icloud' ? 'moving to iCloud' : 'moving to internal'}
-                        </span>
-                        <span className="dot">•</span>
-                        <span>{phaseLabel}</span>
-                        {totalFiles > 0 && (
-                          <>
-                            <span className="dot">•</span>
-                            <span>
-                              {processed.toLocaleString()}/{totalFiles.toLocaleString()} files
-                            </span>
-                          </>
-                        )}
-                      </div>
-                    </>
-                  )
-                ) : (
-                  <div className="card-actions">
-                    <button onClick={() => handleSync(g.id)} className="btn ghost small">Sync</button>
-                    <button onClick={() => handleRemove(g.id)} className="btn ghost small">Remove</button>
-                  </div>
+          {galleries.map((g) => (
+            <li key={g.id} className="card">
+              <Link href={`/desktop/galleries/${g.id}`} className="picg-card-link">
+                <div className="card-title">{g.fullName}</div>
+              </Link>
+              <div className="card-meta">
+                <span>{formatBytes(g.sizeBytes)}</span>
+                {g.defaultBranch && (
+                  <>
+                    <span className="dot">•</span>
+                    <span>{g.defaultBranch}</span>
+                  </>
                 )}
-              </li>
-            );
-          })}
+                {g.lastSyncAt && (
+                  <>
+                    <span className="dot">•</span>
+                    <span>synced {formatRelativeTime(g.lastSyncAt)}</span>
+                  </>
+                )}
+              </div>
+              <div className="card-actions">
+                <button onClick={() => handleSync(g.id)} className="btn ghost small">Sync</button>
+                <button onClick={() => handleRemove(g.id)} className="btn ghost small">Remove</button>
+              </div>
+            </li>
+          ))}
 
           {!cloningEntries.length && !galleries.length && (
             <li className="empty-state">
@@ -691,9 +544,6 @@ export default function GalleriesPage() {
           text-transform: uppercase;
           color: var(--text-muted);
           display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
-        }
-        .storage-tag.icloud {
-          color: var(--accent);
         }
 
         .card-actions { display: flex; gap: 8px; margin-top: 4px; }

--- a/src/core/storage/electron/PreloadBridgeAdapter.ts
+++ b/src/core/storage/electron/PreloadBridgeAdapter.ts
@@ -13,8 +13,6 @@ import type {
   CloneProgress,
   InFlightClone,
   LocalGallery,
-  MigrateDirection,
-  MigrateProgress,
 } from './galleryTypes';
 
 // Renderer-side adapter that forwards every StorageAdapter call to the
@@ -259,24 +257,6 @@ export type PreloadGalleryBridge = {
   // Subscribe to clone-progress events. Returns an unsubscribe fn — call it
   // from a useEffect cleanup to avoid leaks.
   onCloneProgress(handler: (event: CloneProgress) => void): () => void;
-  // Move a gallery between the app's userData and iCloud Drive. The
-  // promise resolves once the swap is complete (manifest updated,
-  // source removed); the returned LocalGallery has the new path and
-  // updated `storage` field.
-  migrate(id: string, direction: MigrateDirection): Promise<LocalGallery>;
-  // Scan the iCloud PicG directory for galleries the local manifest
-  // doesn't know about and add them. Returns the newly-added entries
-  // (decorated with `storage: 'icloud'`); empty array means the scan
-  // turned up nothing new. Safe to call repeatedly.
-  discover(): Promise<LocalGallery[]>;
-  // Absolute path of the iCloud PicG root, e.g.
-  // /Users/<you>/Library/Mobile Documents/com~apple~CloudDocs/PicG.
-  // The renderer surfaces this in a settings hint so the user can
-  // open it in Finder.
-  iCloudRoot(): Promise<string>;
-  // Subscribe to migrate-progress events. Same shape as
-  // onCloneProgress: returns an unsubscribe fn.
-  onMigrateProgress(handler: (event: MigrateProgress) => void): () => void;
   // Subscribe to git-state-change broadcasts. Main fires these
   // after every storage mutation (write/delete/etc.) and after
   // pull/push/undo. Lets the renderer keep its ahead/behind/dirty
@@ -299,8 +279,7 @@ export type GalleryChangedEvent = {
     | 'delete-dir'
     | 'pull'
     | 'push'
-    | 'undo'
-    | 'discover';
+    | 'undo';
 };
 
 // Mirror of PushReceipt in electron/ipc/contract.ts. Same sync rule —

--- a/src/core/storage/electron/galleryTypes.ts
+++ b/src/core/storage/electron/galleryTypes.ts
@@ -10,34 +10,12 @@ export interface LocalGallery {
   fullName: string;      // owner/repo
   htmlUrl: string;
   cloneUrl: string;      // https://github.com/owner/repo.git
-  localPath: string;     // <userData>/galleries/<id> OR <iCloud>/PicG/<id>
+  localPath: string;     // <userData>/galleries/<id>
   defaultBranch?: string;
   addedAt: string;       // ISO timestamp
   lastSyncAt?: string;
   sizeBytes?: number;    // measured on clone + sync; UI shows on cards
-  // Derived (not persisted): inferred from localPath every time the
-  // registry returns a gallery. 'icloud' means the working tree lives
-  // under ~/Library/Mobile Documents/com~apple~CloudDocs/PicG/ — auto-
-  // synced across the user's Macs. 'internal' means it lives under the
-  // app's userData and never leaves this machine.
-  storage?: 'internal' | 'icloud';
 }
-
-export type MigrateDirection = 'to-icloud' | 'to-internal';
-
-// Streamed back over CHANNELS.gallery.migrateProgress while a migrate
-// runs. `phase` follows: counting → copying → verifying → cleanup → done.
-// `processed`/`total` are file counts during 'copying'; the renderer
-// shows them as a "32 / 1240 files" string + a percentage bar.
-export type MigrateProgress = {
-  galleryId: string;
-  direction: MigrateDirection;
-  phase: 'counting' | 'copying' | 'verifying' | 'cleanup' | 'done' | 'error';
-  processed?: number;
-  total?: number;
-  current?: string;      // last file copied — useful for slow machines
-  error?: string;
-};
 
 export type CloneStage =
   | 'receiving'

--- a/src/core/storage/electron/index.ts
+++ b/src/core/storage/electron/index.ts
@@ -23,6 +23,4 @@ export type {
   CloneProgress,
   CloneStage,
   InFlightClone,
-  MigrateDirection,
-  MigrateProgress,
 } from './galleryTypes';

--- a/src/core/storage/index.ts
+++ b/src/core/storage/index.ts
@@ -49,8 +49,6 @@ export type {
   CloneProgress,
   CloneStage,
   InFlightClone,
-  MigrateDirection,
-  MigrateProgress,
   GalleryChangedEvent,
   PushReceipt,
 } from './electron';


### PR DESCRIPTION
## What

Removes the entire "move a gallery to iCloud Drive" system, end to end.

## Why

Every part of the iCloud integration existed only to support migration:
- **Discovery** (`discoverICloud`) only ever finds folders that were *moved* into the `PicG/` iCloud folder.
- **`brctl download`** only materializes galleries that already live in iCloud.
- The **Internal/iCloud storage badge** only distinguishes migrated galleries from local ones.

So once "move to iCloud" goes away, the rest is dead code. Removing it as one coherent unit (per the request to drop 移动到 iCloud 这套逻辑).

## What changed

**Main process**
- `GalleryRegistry`: dropped `migrateToICloud` / `migrateToInternal` / `migrate`, `discoverICloud` / `tryRecognizeGallery`, `triggerICloudDownload`, and the migration-only helpers (`isICloudPath`, `iCloudGalleriesRoot`, `decorate`, `resolveRaw`, `listAll`), plus the `iCloudRoot` field, `migrating` set, `ICLOUD_PICG_DIR`, and now-unused imports (`exec`, `CHANNELS`). `list`/`resolve`/`clone`/`sync` return galleries directly.
- `main.ts`: removed the startup iCloud discovery + `brctl download` bootstrap (and the now-unused `emitGalleryChanged` import).
- IPC (`contract.ts` / `gallery.ts` / `preload.ts`): removed the `migrate` / `discover` / `iCloudRoot` / `migrateProgress` channels, handlers, and bridge methods, plus the `'discover'` cause on `GalleryChangedEvent`.

**Renderer**
- `galleryTypes.ts`: removed `LocalGallery.storage` and the `MigrateDirection` / `MigrateProgress` types (and the two barrel re-exports).
- Galleries list page: removed migrate state/handlers, the migrate-progress card, the iCloud-discovery `onChanged` effect, and the Internal/iCloud badge + CSS. Cards now show Sync / Remove only.
- Gallery detail page: removed the "Move to iCloud / internal" menu item and the `MigrateModal` / `MigrateProgressView` components.

**Docs**
- `desktop-development.md`: dropped the §10 iCloud section, the iCloud notes in §1.2 / §9.4, and the iCloud backlog items; renumbered the trailing sections.

## Reviewer notes

- **No data migration needed.** Existing galleries whose `localPath` already points into iCloud keep working as plain local folders — `storage` was always *derived* from the path, never persisted, so `galleries.json` is unaffected. They simply lose cross-Mac discovery / badge / `brctl` prefetch.
- `tsc` (electron + renderer) and `eslint` pass clean on all changed files. The only `tsc` errors in the tree are pre-existing (`@playwright/test` not installed in this worktree) and unrelated.
- `sync-ux-research.md` still mentions "iCloud Photos / Dropbox" — that's a UX mental-model comparison, not this feature, so it was left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)