### PR TITLE
feat(desktop): add "Open folder" to gallery cards, drop card-level sync

### DIFF
--- a/electron/ipc/contract.ts
+++ b/electron/ipc/contract.ts
@@ -65,6 +65,7 @@ export const CHANNELS = {
     clone: 'gallery:clone',
     cancelClone: 'gallery:cancel-clone',
     remove: 'gallery:remove',
+    openFolder: 'gallery:open-folder',
     sync: 'gallery:sync',
     push: 'gallery:push',
     unpushedCommits: 'gallery:unpushed-commits',
@@ -358,6 +359,10 @@ export interface PicgBridge {
     // matches on that string to dismiss the card without an error.
     cancelClone(id: string): Promise<void>;
     remove(id: string): Promise<void>;
+    // Reveal the gallery's on-disk folder in the OS file manager
+    // (Finder / Explorer). Resolves to '' on success or the OS error
+    // message on failure — the Electron shell.openPath contract.
+    openFolder(id: string): Promise<string>;
     sync(id: string): Promise<LocalGallery>;
     push(id: string): Promise<PushReceipt>;
     unpushedCommits(id: string): Promise<UnpushedCommit[]>;

--- a/electron/ipc/gallery.ts
+++ b/electron/ipc/gallery.ts
@@ -4,7 +4,7 @@
 // long-running call; it pushes progress events back to the requesting
 // webContents on CHANNELS.gallery.cloneProgress.
 
-import { ipcMain } from 'electron';
+import { ipcMain, shell } from 'electron';
 
 import { GalleryRegistry } from '../galleries/GalleryRegistry';
 import { CHANNELS } from './contract';
@@ -51,6 +51,16 @@ export function registerGalleryIpcHandlers(): void {
 
   ipcMain.handle(CHANNELS.gallery.remove, async (_e, id: string) => {
     await getRegistry().remove(id);
+  });
+
+  // Open the gallery's on-disk folder in the OS file manager. Resolve the
+  // path through the registry (never trust a renderer-supplied path) so
+  // only a real managed gallery can be opened. shell.openPath returns ''
+  // on success or an error string on failure; we pass that through.
+  ipcMain.handle(CHANNELS.gallery.openFolder, async (_e, id: string) => {
+    const gallery = await getRegistry().resolve(id);
+    if (!gallery) throw new Error(`Gallery not found: ${id}`);
+    return shell.openPath(gallery.localPath);
   });
 
   ipcMain.handle(CHANNELS.gallery.sync, async (_e, id: string) => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -63,6 +63,7 @@ const bridge: PicgBridge = {
     clone: (...args) => ipcRenderer.invoke(CHANNELS.gallery.clone, ...args),
     cancelClone: (id) => ipcRenderer.invoke(CHANNELS.gallery.cancelClone, id),
     remove: (id) => ipcRenderer.invoke(CHANNELS.gallery.remove, id),
+    openFolder: (id) => ipcRenderer.invoke(CHANNELS.gallery.openFolder, id),
     sync: (id) => ipcRenderer.invoke(CHANNELS.gallery.sync, id),
     push: (id) => ipcRenderer.invoke(CHANNELS.gallery.push, id),
     unpushedCommits: (id) =>

--- a/src/app/desktop/galleries/page.tsx
+++ b/src/app/desktop/galleries/page.tsx
@@ -234,16 +234,6 @@ export default function GalleriesPage() {
     }
   }
 
-  async function handleSync(id: string) {
-    if (!bridge) return;
-    try {
-      const updated = await bridge.gallery.sync(id);
-      setGalleries((prev) => prev.map((g) => (g.id === id ? updated : g)));
-    } catch (err) {
-      setError(`Sync failed: ${err instanceof Error ? err.message : err}`);
-    }
-  }
-
   async function handleRemove(id: string) {
     if (!bridge) return;
     if (!confirm('Remove this gallery from the desktop app? Local files will be deleted.')) return;
@@ -252,6 +242,18 @@ export default function GalleriesPage() {
       setGalleries((prev) => prev.filter((g) => g.id !== id));
     } catch (err) {
       setError(`Remove failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  async function handleOpenFolder(id: string) {
+    if (!bridge) return;
+    try {
+      // shell.openPath resolves to '' on success, or an OS error string
+      // (e.g. the folder was deleted out from under us) on failure.
+      const err = await bridge.gallery.openFolder(id);
+      if (err) setError(`Could not open folder: ${err}`);
+    } catch (err) {
+      setError(`Could not open folder: ${err instanceof Error ? err.message : err}`);
     }
   }
 
@@ -403,7 +405,7 @@ export default function GalleriesPage() {
                 )}
               </div>
               <div className="card-actions">
-                <button onClick={() => handleSync(g.id)} className="btn ghost small">Sync</button>
+                <button onClick={() => handleOpenFolder(g.id)} className="btn ghost small">Open folder</button>
                 <button onClick={() => handleRemove(g.id)} className="btn ghost small">Remove</button>
               </div>
             </li>

--- a/src/core/storage/electron/PreloadBridgeAdapter.ts
+++ b/src/core/storage/electron/PreloadBridgeAdapter.ts
@@ -243,6 +243,10 @@ export type PreloadGalleryBridge = {
   // a cancellation from a real failure.
   cancelClone(id: string): Promise<void>;
   remove(id: string): Promise<void>;
+  // Reveal the gallery's on-disk folder in the OS file manager. Resolves
+  // to '' on success or the OS error string on failure (shell.openPath
+  // contract). Backed by gallery:open-folder in main.
+  openFolder(id: string): Promise<string>;
   sync(id: string): Promise<LocalGallery>;
   push(id: string): Promise<PushReceipt>;
   // Subjects of the commits sitting between origin/<branch> and


### PR DESCRIPTION
## What

Gallery cards in the desktop library get an **Open folder** action, and the card-level **Sync** button is removed.

| Before | After |
|---|---|
| `Sync` · `Remove` | `Open folder` · `Remove` |

## Why

- **Open folder** reveals the gallery's on-disk git clone (`<userData>/galleries/<owner>__<repo>`) in Finder / Explorer — makes the real storage location discoverable for backup, inspection, and migration.
- **Sync** is dropped from the card because pulling is a "while you're working on this gallery" action that already lives on the gallery **detail page** (the ↓ button, which also shows the behind-count). The list card is now purely management (`Open folder` / `Remove`) + navigation into the gallery.

## How

New `gallery:open-folder` IPC, wired exactly like the existing `auth.openExternal`:

- **Main** (`electron/ipc/gallery.ts`): resolves the gallery id through the registry — never trusts a renderer-supplied path, same guard as `sync` / `remove` — then `shell.openPath(localPath)`. The `shell.openPath` result string (`''` = success, otherwise the OS error message) is passed straight back to the renderer, which surfaces a non-empty value as an error banner.
- **Types**: the bridge method is added to **both** parallel definitions that must stay in sync — `PicgBridge` in `electron/ipc/contract.ts` (main / preload) and `PreloadGalleryBridge` in `src/core/storage/electron/PreloadBridgeAdapter.ts` (renderer).

## Notes for reviewers

- No filesystem path crosses the IPC boundary from the renderer; only the gallery `id` does.
- `tsc -p electron` passes. Renderer files compile clean; the only `tsc` noise in this worktree is pre-existing missing optional deps (`@playwright/test`, and `leaflet` until `npm install`), unrelated to this change.
- Verified in a packaged macOS build (`pack:dir`): the list-page chunk contains `Open folder` / `Remove` and zero `Pull` / `Sync` button labels; the detail-page Pull button is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
