### PR TITLE
fix(desktop): preserve ICC color profile in webp/jpeg compress

### DIFF
--- a/electron/ipc/compress.ts
+++ b/electron/ipc/compress.ts
@@ -344,6 +344,8 @@ async function compressImage(
     hasExif: !!inMeta.exif,
     exifBytes: inMeta.exif?.length ?? 0,
     hasXmp: !!inMeta.xmp,
+    hasIcc: inMeta.hasProfile,
+    space: inMeta.space,
     orientation: inMeta.orientation,
   });
 
@@ -351,6 +353,21 @@ async function compressImage(
   // orientation to 1 in the output. Doing this here means the supplement
   // step can safely drop the Orientation tag without leaving a mismatch.
   pipeline = pipeline.rotate();
+
+  // Preserve the source's ICC colour profile. sharp strips all input
+  // metadata by default, which flattens wide-gamut (Display P3) photos to
+  // sRGB — viewers then render them as sRGB and saturated colours look
+  // dull (very visible on vivid landscapes). keepIccProfile() copies the
+  // input profile onto the output without touching pixels (we only
+  // rotate/resize here, never convert colourspace), so P3 pixels keep a
+  // P3 profile; it's a no-op when the input has no profile. The EXIF
+  // re-injection below leaves this intact — exif-library's insert() swaps
+  // only the EXIF segment/chunk and never the APP2/ICCP that carries the
+  // profile. (The Ultra HDR JPEG path is separate — it bypasses sharp via
+  // the Core Image EXR helper + hdrify and manages colour itself — so this
+  // only affects the sharp encode branches: jpeg, the ultrahdr SDR
+  // fallback, and webp.)
+  pipeline = pipeline.keepIccProfile();
 
   // Resolve effective knob values now so the cap branch and the encode
   // branch agree on the same numbers. `request.maxMegapixels === null`
@@ -435,6 +452,8 @@ async function compressImage(
       hasExif: !!outMeta.exif,
       exifBytes: outMeta.exif?.length ?? 0,
       hasXmp: !!outMeta.xmp,
+      hasIcc: outMeta.hasProfile,
+      space: outMeta.space,
       orientation: outMeta.orientation,
     });
   } catch {


### PR DESCRIPTION
## Problem
In the desktop compress pipeline (`electron/ipc/compress.ts`), the sharp encode dropped the source's ICC color profile — sharp strips all input metadata by default. Wide-gamut (Display P3) photos came out profile-less and were rendered as sRGB by viewers, dulling saturated colors (very visible on vivid landscapes).

## Fix
Add `keepIccProfile()` to the shared sharp pipeline so every sharp encode branch carries the input profile through: `jpeg`, the `ultrahdr` SDR fallback, lossless `webp`, and lossy `webp`. It's a no-op when the input has no profile.

The dedicated Ultra HDR JPEG path (`encodeUltraHdrJpeg`, Core Image EXR + hdrify) bypasses sharp and manages color itself, so it's unaffected. The post-encode EXIF re-injection preserves the profile too: `@lfkdsk/exif-library`'s `insert()` only swaps the EXIF segment/chunk and leaves APP2/ICCP intact (verified for both JPEG `mergeSegments` and WebP `insert`).

Also surfaces `hasIcc`/`space` in the input/output diagnostic logs.

## Verification
Reproduced the full pipeline against the repo's real `sharp@0.34.5` + `@lfkdsk/exif-library@2.0.3` on a synthetic Display-P3 source carrying EXIF. For **both jpeg and webp**:
- bug reproduced: encode without the fix → `hasIcc: false`
- with the fix → `hasIcc: true` on encode, **still true after EXIF re-injection**
- preserved profile confirmed P3
- EXIF re-injected, Orientation tag dropped, other tags preserved

`tsc -p electron --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)