### PR TITLE
fix(desktop): Reinhard tone-mapping for Ultra HDR JPEG SDR base

### DIFF
--- a/electron/ipc/compress.ts
+++ b/electron/ipc/compress.ts
@@ -224,7 +224,11 @@ async function encodeUltraHdrJpeg(
     const img = hdrify.readExr(
       new Uint8Array(exr.buffer, exr.byteOffset, exr.byteLength)
     );
-    const encoded = hdrify.encodeGainMap(img);
+    // Reinhard tone-mapping for the SDR base. hdrify's encodeGainMap defaults
+    // to ACES, whose heavy shadow toe crushes dark regions (e.g. a backlit
+    // tree trunk) compared to the source. Reinhard is gentler on shadows and
+    // matches hdrify-cli's own default, which renders faithfully.
+    const encoded = hdrify.encodeGainMap(img, { toneMapping: 'reinhard' });
     const quality = clampInt(request.quality, 0, 100, DEFAULT_QUALITY);
     // Preserve the HEIC's EXIF (camera/lens/date/GPS/exposure). hdrify embeds
     // it BEFORE computing the MPF byte offsets, so the gain map stays valid —


### PR DESCRIPTION
The Ultra HDR JPEG's SDR base was tone-mapped with hdrify's default **ACES** curve, whose heavy shadow toe **crushed dark regions** (e.g. a backlit tree trunk) compared to the source. Switch to **Reinhard** (gentler on shadows), matching `hdrify-cli`'s own default — confirmed faithful against the original.

One-line change to the `encodeGainMap` call in `electron/ipc/compress.ts`; fixes both the compressed output and the compare modal's on-demand HDR original preview (both go through `encodeUltraHdrJpeg`). Verified ACES-vs-Reinhard side by side (trunk regains shadow detail). electron tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)