### PR TITLE
perf(desktop): run hdrify HDR encode in a worker thread (off the main loop)

### DIFF
--- a/electron/ipc/compress.ts
+++ b/electron/ipc/compress.ts
@@ -25,6 +25,7 @@ import sharp from 'sharp';
 import { dump, insert, load, TagNumbers } from '@lfkdsk/exif-library';
 
 import { CHANNELS } from './contract';
+import { encodeUltraHdrInWorker } from './hdrifyWorker';
 import type {
   CompressImageRequest,
   CompressImageResult,
@@ -159,6 +160,27 @@ const importESM = new Function('specifier', 'return import(specifier)') as (
   specifier: string
 ) => Promise<any>;
 
+// Fallback: run the hdrify encode on the main thread (blocks the event loop).
+// Used only when the worker thread is unavailable (encodeUltraHdrInWorker
+// rejects), so HDR output still works even if the worker can't start.
+async function encodeUltraHdrOnMain(
+  exrPath: string,
+  quality: number,
+  exif: Uint8Array | null
+): Promise<Uint8Array> {
+  const exr = await fs.readFile(exrPath);
+  const hdrify = await importESM('hdrify');
+  const img = hdrify.readExr(
+    new Uint8Array(exr.buffer, exr.byteOffset, exr.byteLength)
+  );
+  const encoded = hdrify.encodeGainMap(img, { toneMapping: 'reinhard' });
+  return hdrify.writeJpegGainMap(encoded, {
+    quality,
+    format: 'ultrahdr',
+    ...(exif ? { exif } : {}),
+  });
+}
+
 // Pull the HEIC's EXIF as an APP1 payload ("Exif\0\0" + TIFF) ready for
 // hdrify's writeJpegGainMap `exif` option. exif-library can't parse the HEIC
 // container, so we transcode a tiny JPEG via sips first (sips preserves EXIF)
@@ -219,26 +241,27 @@ async function encodeUltraHdrJpeg(
     if (maxMp != null) args.push('--max-megapixels', String(maxMp));
     await execFileAsync(helper, args);
 
-    const exr = await fs.readFile(exrPath);
-    const hdrify = await importESM('hdrify');
-    const img = hdrify.readExr(
-      new Uint8Array(exr.buffer, exr.byteOffset, exr.byteLength)
-    );
-    // Reinhard tone-mapping for the SDR base. hdrify's encodeGainMap defaults
-    // to ACES, whose heavy shadow toe crushes dark regions (e.g. a backlit
-    // tree trunk) compared to the source. Reinhard is gentler on shadows and
-    // matches hdrify-cli's own default, which renders faithfully.
-    const encoded = hdrify.encodeGainMap(img, { toneMapping: 'reinhard' });
     const quality = clampInt(request.quality, 0, 100, DEFAULT_QUALITY);
     // Preserve the HEIC's EXIF (camera/lens/date/GPS/exposure). hdrify embeds
     // it BEFORE computing the MPF byte offsets, so the gain map stays valid —
     // a post-hoc EXIF insert would shift those offsets and break HDR.
     const exif = request.preserveExif ? await extractHeicExifApp1(input) : null;
-    const jpeg: Uint8Array = hdrify.writeJpegGainMap(encoded, {
-      quality,
-      format: 'ultrahdr',
-      ...(exif ? { exif } : {}),
-    });
+
+    // Encode the gain-map JPEG off the main event loop in a worker thread, so
+    // a batch of HDR imports doesn't stall window controls (hdrify is sync and
+    // CPU-heavy, ~1-3s/image). Tone-mapping is Reinhard (set in the worker) —
+    // ACES, hdrify's default, crushes shadows. Falls back to a main-thread
+    // encode if the worker can't start; slower, but HDR output never breaks.
+    let jpeg: Uint8Array;
+    try {
+      jpeg = await encodeUltraHdrInWorker(exrPath, quality, exif);
+    } catch (err: any) {
+      console.warn(
+        '[picg compress] hdrify worker unavailable, encoding on main thread:',
+        err?.message ?? err
+      );
+      jpeg = await encodeUltraHdrOnMain(exrPath, quality, exif);
+    }
     console.log('[picg compress] HEIC→Ultra HDR JPEG, bytes:', jpeg.length);
     return {
       buffer: jpeg,

--- a/electron/ipc/hdrifyWorker.ts
+++ b/electron/ipc/hdrifyWorker.ts
@@ -1,0 +1,110 @@
+// Offloads the synchronous, CPU-heavy hdrify gain-map encode (readExr →
+// encodeGainMap → writeJpegGainMap) off the Electron MAIN event loop into a
+// worker thread, so a batch of HEIC→HDR-JPEG imports doesn't stall window
+// controls. hdrify is pure-JS and synchronous (~1-3s/image); on the main loop
+// it serializes encodes and lags other IPC/window ops.
+//
+// The worker is an INLINE (eval) script — no separate file to compile, bundle,
+// path-resolve, or asar-unpack — and loads hdrify (ESM) via a Function-wrapped
+// dynamic import, the same trick the main process uses. Main resolves hdrify's
+// absolute path (require.resolve works because main's own import works) and
+// passes it in, so the worker doesn't depend on bare-specifier resolution from
+// its own context. A single persistent worker processes requests serially
+// (hdrify is sync), which is enough to free main's loop. compress.ts falls back
+// to a main-thread encode if the worker can't start — slower, never broken.
+
+import { Worker } from 'node:worker_threads';
+import { pathToFileURL } from 'node:url';
+
+const WORKER_SOURCE = `
+const { parentPort } = require('node:worker_threads');
+const fs = require('node:fs');
+const importESM = new Function('s', 'return import(s)');
+let hdrifyPromise = null;
+parentPort.on('message', async (msg) => {
+  const { id, exrPath, quality, exif, hdrifyUrl } = msg;
+  try {
+    if (!hdrifyPromise) hdrifyPromise = importESM(hdrifyUrl);
+    const hdrify = await hdrifyPromise;
+    const exr = fs.readFileSync(exrPath);
+    const img = hdrify.readExr(new Uint8Array(exr.buffer, exr.byteOffset, exr.byteLength));
+    const encoded = hdrify.encodeGainMap(img, { toneMapping: 'reinhard' });
+    const jpeg = hdrify.writeJpegGainMap(encoded, {
+      quality,
+      format: 'ultrahdr',
+      ...(exif ? { exif } : {}),
+    });
+    const ab = jpeg.buffer.slice(jpeg.byteOffset, jpeg.byteOffset + jpeg.byteLength);
+    parentPort.postMessage({ id, ok: true, jpeg: ab }, [ab]);
+  } catch (err) {
+    parentPort.postMessage({ id, ok: false, error: String((err && err.message) || err) });
+  }
+});
+`;
+
+type Pending = { resolve: (b: Uint8Array) => void; reject: (e: Error) => void };
+
+let worker: Worker | null = null;
+let workerBroken = false;
+let seq = 0;
+const pending = new Map<number, Pending>();
+let hdrifyUrl: string | null = null;
+
+function failAll(err: Error): void {
+  for (const p of pending.values()) p.reject(err);
+  pending.clear();
+}
+
+function getWorker(): Worker | null {
+  if (workerBroken) return null;
+  if (worker) return worker;
+  try {
+    const w = new Worker(WORKER_SOURCE, { eval: true });
+    w.unref(); // don't keep the process alive at quit
+    w.on(
+      'message',
+      (msg: { id: number; ok: boolean; jpeg?: ArrayBuffer; error?: string }) => {
+        const p = pending.get(msg.id);
+        if (!p) return;
+        pending.delete(msg.id);
+        if (msg.ok && msg.jpeg) p.resolve(new Uint8Array(msg.jpeg));
+        else p.reject(new Error(msg.error ?? 'hdrify worker error'));
+      }
+    );
+    w.on('error', (err) => {
+      // Catastrophic failure (e.g. couldn't load hdrify in this packaging):
+      // disable the worker for the session so callers fall back to main.
+      workerBroken = true;
+      worker = null;
+      failAll(err);
+    });
+    w.on('exit', () => {
+      worker = null;
+      failAll(new Error('hdrify worker exited'));
+    });
+    worker = w;
+    return w;
+  } catch {
+    workerBroken = true;
+    return null;
+  }
+}
+
+// Encode an Ultra HDR JPEG from a linear EXR file in the worker thread. The
+// worker reads the EXR off disk itself (the path, not the bytes, crosses the
+// thread boundary), and the resulting JPEG ArrayBuffer is transferred back
+// zero-copy. Rejects if the worker is unavailable so the caller can fall back.
+export function encodeUltraHdrInWorker(
+  exrPath: string,
+  quality: number,
+  exif: Uint8Array | null
+): Promise<Uint8Array> {
+  const w = getWorker();
+  if (!w) return Promise.reject(new Error('hdrify worker unavailable'));
+  if (!hdrifyUrl) hdrifyUrl = pathToFileURL(require.resolve('hdrify')).href;
+  const id = ++seq;
+  return new Promise<Uint8Array>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    w.postMessage({ id, exrPath, quality, exif, hdrifyUrl });
+  });
+}


### PR DESCRIPTION
The Ultra HDR JPEG encode (hdrify `readExr`/`encodeGainMap`/`writeJpegGainMap`) is synchronous and CPU-heavy (~1-3s/image) and ran on the Electron **main event loop**, lagging window controls during HEIC→HDR-JPEG batches.

Move it to a persistent **worker_thread** (`electron/ipc/hdrifyWorker.ts`):
- Inline (eval) worker — no separate file to bundle/path-resolve/asar-unpack.
- Main passes the `require.resolve('hdrify')` URL so the worker doesn't depend on bare-specifier resolution from its own context.
- Only the EXR **file path** crosses the boundary (worker reads it); the result JPEG is transferred back zero-copy.
- **Main-thread fallback** if the worker can't start — slower, but HDR output never breaks.

Verified in the real Electron runtime: the worker produced a correct `hdrgm:Version 1.0` + MPF-2 Ultra HDR JPEG. electron tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)