### PR TITLE
feat(desktop): auto sign-out when a git push/pull hits an expired token

### DIFF
--- a/src/app/desktop/galleries/[id]/[album]/page.tsx
+++ b/src/app/desktop/galleries/[id]/[album]/page.tsx
@@ -13,6 +13,7 @@ import {
   type PicgBridge,
   type StorageAdapter,
 } from '@/core/storage';
+import { logoutIfGitAuthError } from '@/lib/github';
 import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 import { useAdapterImage } from '@/components/desktop/useAdapterImage';
 import { fireUndoToast, UndoToastHost } from '@/components/desktop/UndoToast';
@@ -267,6 +268,9 @@ export default function AlbumPage() {
         window.location.assign(href);
       }
     } catch (err) {
+      // A revoked/expired token surfaces here as a git auth failure; sign
+      // out and bounce to the sign-in page rather than showing a raw error.
+      if (await logoutIfGitAuthError(err)) return;
       setOpError(err instanceof Error ? err.message : String(err));
       setPulling(false);
     }
@@ -281,6 +285,9 @@ export default function AlbumPage() {
       const s = await bridge.gallery.status(gallery.id);
       setAhead(s.ahead);
     } catch (err) {
+      // A revoked/expired token surfaces here as a git auth failure; sign
+      // out and bounce to the sign-in page rather than showing a raw error.
+      if (await logoutIfGitAuthError(err)) return;
       setOpError(err instanceof Error ? err.message : String(err));
     } finally {
       setPushing(false);

--- a/src/app/desktop/galleries/[id]/page.tsx
+++ b/src/app/desktop/galleries/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   type PushReceipt,
   type StorageAdapter,
 } from '@/core/storage';
+import { isGitAuthError, desktopLogout, logoutIfGitAuthError } from '@/lib/github';
 import { Topbar, DesktopTheme } from '@/components/DesktopChrome';
 import { useAdapterImage } from '@/components/desktop/useAdapterImage';
 import { EditGalleryModal } from '@/components/desktop/EditGalleryModal';
@@ -128,8 +129,17 @@ export default function GalleryDetailPage() {
         : bridge.gallery.status(gallery.id);
       statusPromise
         .then(applyStatus)
-        .catch(() => {
-          if (!remote) return;
+        .catch((err) => {
+          if (!remote || cancelled) return;
+          // The entry-time network refresh is the earliest place a
+          // revoked/expired token shows up. Sign out on a genuine auth
+          // failure; let everything else (offline, GitHub down) fall
+          // through to the local-only status so the gallery stays
+          // browsable offline.
+          if (isGitAuthError(err)) {
+            void desktopLogout('auth-expired');
+            return;
+          }
           bridge.gallery.status(gallery.id).then(applyStatus).catch(() => {});
         });
     };
@@ -275,6 +285,9 @@ export default function GalleryDetailPage() {
         window.location.assign(href);
       }
     } catch (err) {
+      // A revoked/expired token surfaces here as a git auth failure; sign
+      // out and bounce to the sign-in page rather than showing a raw error.
+      if (await logoutIfGitAuthError(err)) return;
       setOpError(err instanceof Error ? err.message : String(err));
       setPulling(false);
     }
@@ -298,6 +311,9 @@ export default function GalleryDetailPage() {
       setAhead(s.ahead);
       setBehind(s.behind);
     } catch (err) {
+      // A revoked/expired token surfaces here as a git auth failure; sign
+      // out and bounce to the sign-in page rather than showing a raw error.
+      if (await logoutIfGitAuthError(err)) return;
       setOpError(err instanceof Error ? err.message : String(err));
     } finally {
       setPushing(false);

--- a/src/app/desktop/login/page.tsx
+++ b/src/app/desktop/login/page.tsx
@@ -28,6 +28,20 @@ export default function DesktopLoginPage() {
     setBridge(getPicgBridge());
   }, []);
 
+  // If a forced sign-out bounced us here (desktopLogout appends
+  // ?reason=auth-expired when a push/pull hit a revoked or expired token),
+  // explain why instead of dropping the user on a bare sign-in screen.
+  useEffect(() => {
+    const reason = new URLSearchParams(window.location.search).get('reason');
+    if (reason === 'auth-expired') {
+      setPhase({
+        kind: 'error',
+        message:
+          'Your GitHub session expired or the access token was revoked. Please sign in again.',
+      });
+    }
+  }, []);
+
   // Subscribe to picg://oauth callbacks dispatched by main. We mount the
   // listener even before the user clicks Sign in, in case main captured
   // a callback URL while the renderer was still booting.

--- a/src/components/DesktopChrome.tsx
+++ b/src/components/DesktopChrome.tsx
@@ -8,7 +8,7 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 
-import { clearGitHubToken, getGitHubToken } from '@/lib/github';
+import { desktopLogout, getGitHubToken } from '@/lib/github';
 import { getStoredUser, type GitHubUser } from '@/lib/auth';
 import { getPicgBridge } from '@/core/storage';
 import { InfoToastHost, fireInfoToast } from '@/components/desktop/InfoToast';
@@ -186,26 +186,11 @@ export function Topbar({ actions }: { actions?: ReactNode }) {
   }, []);
 
   async function handleLogout() {
-    // Clear the durable on-disk copy first (was Keychain, now
-    // <userData>/auth.json) so a stale token can't "restore" us into a
-    // logged-in state on next launch.
-    const bridge = getPicgBridge();
-    if (bridge) {
-      try {
-        await bridge.auth.clearToken();
-      } catch {
-        /* ignore */
-      }
-    }
-    // Don't call the shared logout() — it redirects to /login, which is
-    // the web sign-in page. Desktop has its own /desktop/login. We
-    // still clear the renderer-side localStorage token via
-    // clearGitHubToken (re-exported through getGitHubToken's module),
-    // then hard-nav to the desktop login.
-    clearGitHubToken();
-    if (typeof window !== 'undefined') {
-      window.location.href = '/desktop/login';
-    }
+    // Shared with the auto-logout-on-auth-failure path (see desktopLogout):
+    // clears the durable on-disk token first so a stale copy can't restore
+    // the session on next launch, then the renderer cache, then hard-navs to
+    // /desktop/login (not the web /login the shared logout() uses).
+    await desktopLogout();
   }
 
   return (

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -12,6 +12,7 @@ import {
   decodePath,
   encodePath,
   GITHUB_API_BASE,
+  getPicgBridge,
   checkRepositorySecret as coreCheckRepositorySecret,
   checkTokenPermissions as coreCheckTokenPermissions,
   createRepo as coreCreateRepo,
@@ -109,6 +110,56 @@ export function logout(): void {
   if (typeof window !== 'undefined') {
     window.location.href = '/login';
   }
+}
+
+// Recognizes a GitHub git-over-HTTPS authentication failure. These surface
+// when the stored OAuth token has been revoked or expired: `git push`/`pull`
+// reject with "remote: Invalid username or token. Password authentication is
+// not supported for Git operations." / "fatal: Authentication failed", and the
+// IPC layer forwards that string into the rejected promise the renderer awaits.
+// We match the stable substrings rather than the exact message so a git version
+// bump, locale, or differing repo URL doesn't slip past us.
+export function isGitAuthError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    msg.includes('invalid username or token') ||
+    msg.includes('password authentication is not supported') ||
+    msg.includes('authentication failed') ||
+    msg.includes('could not read username')
+  );
+}
+
+// Desktop sign-out. Drops the durable on-disk token (main process) first so a
+// stale copy can't restore the session on next launch, then clears the
+// renderer's localStorage/cookie cache and hard-navs to the desktop sign-in.
+// Distinct from the web logout() above, which targets /login. Shared by the
+// Topbar "Sign out" action and the auto-logout-on-auth-failure path; the
+// optional `reason` is surfaced on the sign-in page so a forced logout can
+// explain itself instead of dropping the user on a bare screen.
+export async function desktopLogout(reason?: string): Promise<void> {
+  const bridge = getPicgBridge();
+  if (bridge) {
+    try {
+      await bridge.auth.clearToken();
+    } catch {
+      /* clear the renderer copy regardless */
+    }
+  }
+  clearGitHubToken();
+  if (typeof window !== 'undefined') {
+    window.location.href = reason
+      ? `/desktop/login?reason=${encodeURIComponent(reason)}`
+      : '/desktop/login';
+  }
+}
+
+// If `err` is a GitHub auth failure, sign the desktop user out and resolve true
+// so the caller stops (the page is already navigating to the sign-in). Resolves
+// false for any other error, leaving the caller to surface it normally.
+export async function logoutIfGitAuthError(err: unknown): Promise<boolean> {
+  if (!isGitAuthError(err)) return false;
+  await desktopLogout('auth-expired');
+  return true;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

When the stored GitHub OAuth token is revoked or expired, git push/pull — and the entry-time status refresh — fail with `Invalid username or token` / `Authentication failed`. Previously that surfaced as a raw error string in the page. Now the app detects the auth failure, signs the user out, and bounces to `/desktop/login` with a "session expired" notice.

## Changes

- **`src/lib/github.ts`** — shared helpers: `isGitAuthError` (matches the stable GitHub auth-failure substrings), `desktopLogout(reason?)` (clears the durable on-disk token + renderer cache, navigates to `/desktop/login`), and `logoutIfGitAuthError`.
- **Push + pull handlers** on both gallery pages (`[id]/page.tsx`, `[id]/[album]/page.tsx`) call `logoutIfGitAuthError(err)` in their catch blocks.
- **Entry-time `refreshStatus` fetch** (`[id]/page.tsx`) signs out **only** on a genuine auth failure — offline / GitHub-down / network errors still fall back to local-only status so the gallery stays browsable offline. Guarded by the effect's `cancelled` flag.
- **`DesktopChrome.tsx`** — the manual "Sign out" menu action now reuses `desktopLogout` (de-dupes the logic).
- **`/desktop/login`** — shows a notice when arriving via `?reason=auth-expired`.

## Verification

`tsc --noEmit` and ESLint clean on all changed files (pre-existing worktree errors from uninstalled `@playwright/test` / `leaflet` are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)